### PR TITLE
Feature/user: 본인 정보 조회, 회원 탈퇴 구현

### DIFF
--- a/src/auth/application/oauth-login/oauth-login.use-case.ts
+++ b/src/auth/application/oauth-login/oauth-login.use-case.ts
@@ -8,7 +8,7 @@ import { OAuthProviderType } from 'src/auth/domain/value-object/oauth-provider.e
 import { AuthEntity } from 'src/auth/infrastructure/orm-entity/auth.entity';
 import { JwtProvider } from 'src/auth/infrastructure/provider/jwt.provider';
 import { Identifier } from 'src/shared/domain/value-object/identifier';
-import { CreateUserUseCase } from 'src/user/application/use-case/create-user.use-case';
+import { CreateUserUseCase } from 'src/user/application/create-user/create-user.use-case';
 import { Role } from 'src/user/domain/value-object/role.enum';
 import { OAuthLoginRequestDto } from './dto/oauth-login.request.dto';
 import { OAuthLoginResponseDto } from './dto/oauth-login.response.dto';
@@ -50,14 +50,17 @@ export class OAuthLoginUseCase {
     const existingAuth = await this.authRepository.findByOAuthIdandProvider(oauthId, provider);
     if (existingAuth) return existingAuth;
 
-    const now = new Date();
     const userId = Identifier.create();
-    await this.createUserUseCase.execute(userId, email, Role.GENERAL);
+    await this.createUserUseCase.execute({
+      userId,
+      email,
+      role: Role.GENERAL,
+    });
 
     const auth = Auth.create({
       id: Identifier.create(),
-      createdAt: now,
-      updatedAt: now,
+      createdAt: this.now,
+      updatedAt: this.now,
       oauthId: oauthId,
       provider: provider,
       refreshToken: null,

--- a/src/auth/infrastructure/strategy/jwt-refresh.strategy.ts
+++ b/src/auth/infrastructure/strategy/jwt-refresh.strategy.ts
@@ -29,7 +29,6 @@ export class JwtRefreshStrategy extends PassportStrategy(Strategy, 'jwt-refresh'
   }
 
   validate(payload: RefreshTokenPayload): RefreshTokenPayload {
-    console.log(payload);
     return payload;
   }
 }

--- a/src/user/application/create-user/create-user.use-case.ts
+++ b/src/user/application/create-user/create-user.use-case.ts
@@ -1,10 +1,9 @@
 import { InjectRepository } from '@mikro-orm/nestjs';
 import { Injectable } from '@nestjs/common';
-import { Identifier } from 'src/shared/domain/value-object/identifier';
 import { User } from 'src/user/domain/entity/user';
 import { UserRepository } from 'src/user/domain/repository/user.repository';
-import { Role } from 'src/user/domain/value-object/role.enum';
 import { UserEntity } from 'src/user/infrastructure/orm-entity/user.entity';
+import { CreateUserRequestDto } from './dto/create-user.request.dto';
 
 @Injectable()
 export class CreateUserUseCase {
@@ -13,7 +12,8 @@ export class CreateUserUseCase {
     private readonly userRepository: UserRepository,
   ) {}
 
-  async execute(userId: Identifier, email: string, role: Role): Promise<void> {
+  async execute(createUserRequestDto: CreateUserRequestDto): Promise<void> {
+    const { userId, email, role } = createUserRequestDto;
     const now = new Date();
     const user = User.create({
       id: userId,
@@ -21,7 +21,6 @@ export class CreateUserUseCase {
       updatedAt: now,
       email: email,
       role: role,
-      scrapIds: [],
     });
 
     await this.userRepository.save(user);

--- a/src/user/application/create-user/dto/create-user.request.dto.ts
+++ b/src/user/application/create-user/dto/create-user.request.dto.ts
@@ -1,0 +1,19 @@
+import { Type } from 'class-transformer';
+import { IsEnum, IsNotEmpty, IsString, ValidateNested } from 'class-validator';
+import { Identifier } from 'src/shared/domain/value-object/identifier';
+import { Role } from 'src/user/domain/value-object/role.enum';
+
+export class CreateUserRequestDto {
+  @Type(() => Identifier)
+  @ValidateNested()
+  @IsNotEmpty()
+  userId: Identifier;
+
+  @IsString()
+  @IsNotEmpty()
+  email: string;
+
+  @IsEnum(Role)
+  @IsNotEmpty()
+  role: Role;
+}

--- a/src/user/application/delete-my-info/delete-my-info.use-case.ts
+++ b/src/user/application/delete-my-info/delete-my-info.use-case.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import { DeleteMyInfoRequestDto } from './dto/delete-my-info.request.dto';
+import { InjectRepository } from '@mikro-orm/nestjs';
+import { UserEntity } from 'src/user/infrastructure/orm-entity/user.entity';
+import { UserRepository } from 'src/user/domain/repository/user.repository';
+
+@Injectable()
+export class DeleteMyInfoUseCase {
+  constructor(
+    @InjectRepository(UserEntity)
+    private readonly userRepository: UserRepository,
+  ) {}
+
+  async execute(deleteMyInfoRequestDto: DeleteMyInfoRequestDto): Promise<void> {
+    const { userId } = deleteMyInfoRequestDto;
+
+    await this.userRepository.delete(userId);
+  }
+}

--- a/src/user/application/delete-my-info/delete-my-info.use-case.ts
+++ b/src/user/application/delete-my-info/delete-my-info.use-case.ts
@@ -14,6 +14,6 @@ export class DeleteMyInfoUseCase {
   async execute(deleteMyInfoRequestDto: DeleteMyInfoRequestDto): Promise<void> {
     const { userId } = deleteMyInfoRequestDto;
 
-    await this.userRepository.delete(userId);
+    await this.userRepository.deleteById(userId);
   }
 }

--- a/src/user/application/delete-my-info/dto/delete-my-info.request.dto.ts
+++ b/src/user/application/delete-my-info/dto/delete-my-info.request.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class DeleteMyInfoRequestDto {
+  @IsString()
+  @IsNotEmpty()
+  userId: string;
+}

--- a/src/user/application/get-my-info/dto/get-my-info.request.dto.ts
+++ b/src/user/application/get-my-info/dto/get-my-info.request.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class GetMyInfoRequestDto {
+  @IsString()
+  @IsNotEmpty()
+  userId: string;
+}

--- a/src/user/application/get-my-info/dto/get-my-info.response.dto.ts
+++ b/src/user/application/get-my-info/dto/get-my-info.response.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class GetMyInfoResponseDto {
+  @IsString()
+  @IsNotEmpty()
+  email: string;
+}

--- a/src/user/application/get-my-info/dto/get-my-info.response.dto.ts
+++ b/src/user/application/get-my-info/dto/get-my-info.response.dto.ts
@@ -1,7 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty, IsString } from 'class-validator';
 
 export class GetMyInfoResponseDto {
   @IsString()
   @IsNotEmpty()
+  @ApiProperty({
+    description: '사용자 이메일',
+    example: 'aaaaaaa@aaaaa.com',
+  })
   email: string;
 }

--- a/src/user/application/get-my-info/get-my-info.use-case.ts
+++ b/src/user/application/get-my-info/get-my-info.use-case.ts
@@ -1,0 +1,22 @@
+import { InjectRepository } from '@mikro-orm/nestjs';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { UserRepository } from 'src/user/domain/repository/user.repository';
+import { UserEntity } from 'src/user/infrastructure/orm-entity/user.entity';
+import { GetMyInfoRequestDto } from './dto/get-my-info.request.dto';
+import { GetMyInfoResponseDto } from './dto/get-my-info.response.dto';
+
+@Injectable()
+export class GetMyInfoUseCase {
+  constructor(
+    @InjectRepository(UserEntity)
+    private readonly userRepository: UserRepository,
+  ) {}
+
+  async execute(getMyInfoRequestDto: GetMyInfoRequestDto): Promise<GetMyInfoResponseDto> {
+    const { userId } = getMyInfoRequestDto;
+    const user = await this.userRepository.findById(userId);
+    if (!user) throw new NotFoundException('존재하지 않는 사용자입니다.');
+
+    return { email: user.email };
+  }
+}

--- a/src/user/domain/entity/user.ts
+++ b/src/user/domain/entity/user.ts
@@ -1,11 +1,9 @@
 import { Role } from 'src/user/domain/value-object/role.enum';
 import { BaseDomainEntity, BaseEntityProps } from 'src/shared/domain/entity/base.entity';
-import { Identifier } from 'src/shared/domain/value-object/identifier';
 
 export interface UserProps extends BaseEntityProps {
   email: string;
   role: Role;
-  scrapIds: Identifier[];
 }
 export class User extends BaseDomainEntity<UserProps> {
   protected constructor(props: UserProps) {
@@ -22,9 +20,5 @@ export class User extends BaseDomainEntity<UserProps> {
 
   get role(): Role {
     return this.props.role;
-  }
-
-  get scrapIds(): Identifier[] | undefined {
-    return this.props.scrapIds;
   }
 }

--- a/src/user/domain/repository/user.repository.ts
+++ b/src/user/domain/repository/user.repository.ts
@@ -3,7 +3,7 @@ import { User } from '../entity/user';
 export interface UserRepository {
   save(user: User): Promise<void>;
   findById(userId: string): Promise<User | null>;
-  delete(userId: string): Promise<void>;
+  deleteById(userId: string): Promise<void>;
 }
 
 export const USER_REPOSITORY = Symbol('USER_REPOSITORY');

--- a/src/user/domain/repository/user.repository.ts
+++ b/src/user/domain/repository/user.repository.ts
@@ -2,6 +2,7 @@ import { User } from '../entity/user';
 
 export interface UserRepository {
   save(user: User): Promise<void>;
+  findById(userId: string): Promise<User | null>;
 }
 
 export const USER_REPOSITORY = Symbol('USER_REPOSITORY');

--- a/src/user/domain/repository/user.repository.ts
+++ b/src/user/domain/repository/user.repository.ts
@@ -3,6 +3,7 @@ import { User } from '../entity/user';
 export interface UserRepository {
   save(user: User): Promise<void>;
   findById(userId: string): Promise<User | null>;
+  delete(userId: string): Promise<void>;
 }
 
 export const USER_REPOSITORY = Symbol('USER_REPOSITORY');

--- a/src/user/infrastructure/mapper/user.mapper.ts
+++ b/src/user/infrastructure/mapper/user.mapper.ts
@@ -10,7 +10,6 @@ export class UserMapper {
       updatedAt: entity.updatedAt,
       email: entity.email,
       role: entity.role,
-      scrapIds: entity.scraps ? entity.scraps.map((scrap) => Identifier.from(scrap.id)) : [],
     });
   }
 

--- a/src/user/infrastructure/orm-entity/user.entity.ts
+++ b/src/user/infrastructure/orm-entity/user.entity.ts
@@ -1,4 +1,4 @@
-import { Cascade, Entity, OneToMany, OneToOne, Property } from '@mikro-orm/core';
+import { Cascade, Collection, Entity, OneToMany, OneToOne, Property } from '@mikro-orm/core';
 import { Role } from 'src/user/domain/value-object/role.enum';
 import { AuthEntity } from 'src/auth/infrastructure/orm-entity/auth.entity';
 import { BaseEntity } from 'src/shared/infrastructure/orm-entity/base.entity';
@@ -17,5 +17,5 @@ export class UserEntity extends BaseEntity {
   auth: AuthEntity;
 
   @OneToMany(() => ScrapEntity, (scrap) => scrap.user, { nullable: true, cascade: [Cascade.ALL] })
-  scraps: ScrapEntity[];
+  scraps = new Collection<ScrapEntity>(this);
 }

--- a/src/user/infrastructure/repository/user.repository.impl.ts
+++ b/src/user/infrastructure/repository/user.repository.impl.ts
@@ -3,6 +3,7 @@ import { User } from 'src/user/domain/entity/user';
 import { UserRepository } from 'src/user/domain/repository/user.repository';
 import { UserMapper } from '../mapper/user.mapper';
 import { UserEntity } from '../orm-entity/user.entity';
+import { NotFoundException } from '@nestjs/common';
 
 export class UserRepositoryImpl extends EntityRepository<UserEntity> implements UserRepository {
   async save(user: User): Promise<void> {
@@ -16,5 +17,12 @@ export class UserRepositoryImpl extends EntityRepository<UserEntity> implements 
     console.log(userEntity);
 
     return UserMapper.toDomain(userEntity);
+  }
+
+  async delete(userId: string): Promise<void> {
+    const userEntity = await this.findOne({ id: userId }, { populate: ['auth', 'scraps'] });
+    if (!userEntity) throw new NotFoundException('존재하지 않는 유저입니다.');
+
+    await this.em.removeAndFlush(userEntity);
   }
 }

--- a/src/user/infrastructure/repository/user.repository.impl.ts
+++ b/src/user/infrastructure/repository/user.repository.impl.ts
@@ -14,7 +14,6 @@ export class UserRepositoryImpl extends EntityRepository<UserEntity> implements 
   async findById(userId: string): Promise<User | null> {
     const userEntity = await this.findOne({ id: userId });
     if (!userEntity) return null;
-    console.log(userEntity);
 
     return UserMapper.toDomain(userEntity);
   }

--- a/src/user/infrastructure/repository/user.repository.impl.ts
+++ b/src/user/infrastructure/repository/user.repository.impl.ts
@@ -9,4 +9,12 @@ export class UserRepositoryImpl extends EntityRepository<UserEntity> implements 
     const userEntity = UserMapper.toEntity(user);
     await this.em.persistAndFlush(userEntity);
   }
+
+  async findById(userId: string): Promise<User | null> {
+    const userEntity = await this.findOne({ id: userId });
+    if (!userEntity) return null;
+    console.log(userEntity);
+
+    return UserMapper.toDomain(userEntity);
+  }
 }

--- a/src/user/infrastructure/repository/user.repository.impl.ts
+++ b/src/user/infrastructure/repository/user.repository.impl.ts
@@ -18,7 +18,7 @@ export class UserRepositoryImpl extends EntityRepository<UserEntity> implements 
     return UserMapper.toDomain(userEntity);
   }
 
-  async delete(userId: string): Promise<void> {
+  async deleteById(userId: string): Promise<void> {
     const userEntity = await this.findOne({ id: userId }, { populate: ['auth', 'scraps'] });
     if (!userEntity) throw new NotFoundException('존재하지 않는 유저입니다.');
 

--- a/src/user/presentation/user.controller.spec.ts
+++ b/src/user/presentation/user.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UserController } from './user.controller';
+
+describe('UserController', () => {
+  let controller: UserController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UserController],
+    }).compile();
+
+    controller = module.get<UserController>(UserController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/user/presentation/user.controller.ts
+++ b/src/user/presentation/user.controller.ts
@@ -1,0 +1,20 @@
+import { Controller, Delete, Get, Patch } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+
+@ApiTags('user')
+@Controller('user')
+export class UserController {
+  constructor() {}
+
+  @Get('me')
+  async getMyInfo() {}
+
+  @Delete('me')
+  async deleteMyInfo() {}
+
+  @Get('scrap')
+  async getMyScrap() {}
+
+  @Patch('scrap')
+  async updateScrap() {}
+}

--- a/src/user/presentation/user.controller.ts
+++ b/src/user/presentation/user.controller.ts
@@ -4,6 +4,7 @@ import { GetMyInfoUseCase } from '../application/get-my-info/get-my-info.use-cas
 import { AuthGuard } from '@nestjs/passport';
 import { User, UserPayload } from 'src/shared/presentation/decorator/user.decorator';
 import { DeleteMyInfoUseCase } from '../application/delete-my-info/delete-my-info.use-case';
+import { UserDocs } from './user.docs';
 
 @ApiTags('user')
 @Controller('user')
@@ -13,16 +14,18 @@ export class UserController {
     private readonly deleteMyInfoUseCase: DeleteMyInfoUseCase,
   ) {}
 
-  @UseGuards(AuthGuard('jwt-access'))
   @Get('me')
+  @UseGuards(AuthGuard('jwt-access'))
+  @UserDocs('getMyInfo')
   async getMyInfo(@User() user: UserPayload) {
     const { email } = await this.getMyInfoUseCase.execute({ userId: user.userId });
 
     return { email };
   }
 
-  @UseGuards(AuthGuard('jwt-access'))
   @Delete('me')
+  @UseGuards(AuthGuard('jwt-access'))
+  @UserDocs('deleteMyInfo')
   async deleteMyInfo(@User() user: UserPayload) {
     await this.deleteMyInfoUseCase.execute({ userId: user.userId });
   }

--- a/src/user/presentation/user.controller.ts
+++ b/src/user/presentation/user.controller.ts
@@ -1,13 +1,21 @@
-import { Controller, Delete, Get, Patch } from '@nestjs/common';
+import { Controller, Delete, Get, Patch, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
+import { GetMyInfoUseCase } from '../application/get-my-info/get-my-info.use-case';
+import { AuthGuard } from '@nestjs/passport';
+import { User, UserPayload } from 'src/shared/presentation/decorator/user.decorator';
 
 @ApiTags('user')
 @Controller('user')
 export class UserController {
-  constructor() {}
+  constructor(private readonly getMyInfoUseCase: GetMyInfoUseCase) {}
 
+  @UseGuards(AuthGuard('jwt-access'))
   @Get('me')
-  async getMyInfo() {}
+  async getMyInfo(@User() user: UserPayload) {
+    const { email } = await this.getMyInfoUseCase.execute({ userId: user.userId });
+
+    return { email };
+  }
 
   @Delete('me')
   async deleteMyInfo() {}

--- a/src/user/presentation/user.controller.ts
+++ b/src/user/presentation/user.controller.ts
@@ -3,11 +3,15 @@ import { ApiTags } from '@nestjs/swagger';
 import { GetMyInfoUseCase } from '../application/get-my-info/get-my-info.use-case';
 import { AuthGuard } from '@nestjs/passport';
 import { User, UserPayload } from 'src/shared/presentation/decorator/user.decorator';
+import { DeleteMyInfoUseCase } from '../application/delete-my-info/delete-my-info.use-case';
 
 @ApiTags('user')
 @Controller('user')
 export class UserController {
-  constructor(private readonly getMyInfoUseCase: GetMyInfoUseCase) {}
+  constructor(
+    private readonly getMyInfoUseCase: GetMyInfoUseCase,
+    private readonly deleteMyInfoUseCase: DeleteMyInfoUseCase,
+  ) {}
 
   @UseGuards(AuthGuard('jwt-access'))
   @Get('me')
@@ -17,8 +21,11 @@ export class UserController {
     return { email };
   }
 
+  @UseGuards(AuthGuard('jwt-access'))
   @Delete('me')
-  async deleteMyInfo() {}
+  async deleteMyInfo(@User() user: UserPayload) {
+    await this.deleteMyInfoUseCase.execute({ userId: user.userId });
+  }
 
   @Get('scrap')
   async getMyScrap() {}

--- a/src/user/presentation/user.docs.ts
+++ b/src/user/presentation/user.docs.ts
@@ -1,0 +1,42 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiNotFoundResponse, ApiOkResponse, ApiOperation, ApiUnauthorizedResponse } from '@nestjs/swagger';
+import { createDocs } from 'src/shared/presentation/docs/base.docs';
+import { GetMyInfoResponseDto } from '../application/get-my-info/dto/get-my-info.response.dto';
+
+export type UserEndpoint = 'getMyInfo' | 'deleteMyInfo';
+
+export const UserDocs = createDocs<UserEndpoint>({
+  getMyInfo: () =>
+    applyDecorators(
+      ApiOperation({
+        summary: '본인 정보 조회',
+        description: '로그인 사용자 정보 조회',
+      }),
+      ApiOkResponse({
+        description: '사용자 이메일 정보 반환',
+        type: GetMyInfoResponseDto,
+      }),
+      ApiUnauthorizedResponse({
+        description: '유효하지 않은 access token',
+      }),
+      ApiNotFoundResponse({
+        description: '존재하지 않는 사용자',
+      }),
+    ),
+  deleteMyInfo: () =>
+    applyDecorators(
+      ApiOperation({
+        summary: '회원탈퇴',
+        description: '회원탈퇴',
+      }),
+      ApiOkResponse({
+        description: '회원탈퇴 성공',
+      }),
+      ApiUnauthorizedResponse({
+        description: '유효하지 않은 access token',
+      }),
+      ApiNotFoundResponse({
+        description: '존재하지 않는 사용자',
+      }),
+    ),
+});

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -5,12 +5,13 @@ import { USER_REPOSITORY } from './domain/repository/user.repository';
 import { USER_SCRAP_REPOSITORY } from './domain/repository/user-scrap.repository';
 import { MikroOrmModule } from '@mikro-orm/nestjs';
 import { UserEntity } from './infrastructure/orm-entity/user.entity';
-import { CreateUserUseCase } from './application/use-case/create-user.use-case';
+import { CreateUserUseCase } from './application/create-user/create-user.use-case';
 import { ScrapEntity } from './infrastructure/orm-entity/scrap.entity';
 import { UserController } from './presentation/user.controller';
 import { GetMyInfoUseCase } from './application/get-my-info/get-my-info.use-case';
+import { DeleteMyInfoUseCase } from './application/delete-my-info/delete-my-info.use-case';
 
-const useCases = [CreateUserUseCase, GetMyInfoUseCase];
+const useCases = [CreateUserUseCase, GetMyInfoUseCase, DeleteMyInfoUseCase];
 
 @Module({
   imports: [MikroOrmModule.forFeature([UserEntity, ScrapEntity])],

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -8,8 +8,9 @@ import { UserEntity } from './infrastructure/orm-entity/user.entity';
 import { CreateUserUseCase } from './application/use-case/create-user.use-case';
 import { ScrapEntity } from './infrastructure/orm-entity/scrap.entity';
 import { UserController } from './presentation/user.controller';
+import { GetMyInfoUseCase } from './application/get-my-info/get-my-info.use-case';
 
-const useCases = [CreateUserUseCase];
+const useCases = [CreateUserUseCase, GetMyInfoUseCase];
 
 @Module({
   imports: [MikroOrmModule.forFeature([UserEntity, ScrapEntity])],

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -7,6 +7,7 @@ import { MikroOrmModule } from '@mikro-orm/nestjs';
 import { UserEntity } from './infrastructure/orm-entity/user.entity';
 import { CreateUserUseCase } from './application/use-case/create-user.use-case';
 import { ScrapEntity } from './infrastructure/orm-entity/scrap.entity';
+import { UserController } from './presentation/user.controller';
 
 const useCases = [CreateUserUseCase];
 
@@ -24,5 +25,6 @@ const useCases = [CreateUserUseCase];
     },
   ],
   exports: [...useCases],
+  controllers: [UserController],
 })
 export class UserModule {}


### PR DESCRIPTION
**작업내용**
- 본인 정보 조회 구현
  - access token의 id값으로 유저 정보 조회
- 회원탈퇴 구현
  - access token의 id값으로 회원탈퇴 처리

※ 논의 사항
soft delete에 대해 고민해볼 필요가 있을 것 같음. user 뿐만 아니라 article 등 다른 도메인에서도 마찬가지.