### PR TITLE
Feature/scrap: 스크랩 목록 조회 api 구현

### DIFF
--- a/src/article/domain/entity/article.ts
+++ b/src/article/domain/entity/article.ts
@@ -21,6 +21,11 @@ export class Article extends BaseDomainEntity<ArticleProps> {
     super(props);
   }
 
+  increaseScrapCount(): void {
+    this.props.scrapCount += 1;
+    this.props.updatedAt = new Date();
+  }
+
   get title(): string {
     return this.props.title;
   }

--- a/src/article/domain/entity/article.ts
+++ b/src/article/domain/entity/article.ts
@@ -26,6 +26,13 @@ export class Article extends BaseDomainEntity<ArticleProps> {
     this.props.updatedAt = new Date();
   }
 
+  decreaseScrapCount(): void {
+    if (this.props.scrapCount > 0) {
+      this.props.scrapCount -= 1;
+      this.props.updatedAt = new Date();
+    }
+  }
+
   get title(): string {
     return this.props.title;
   }

--- a/src/article/domain/repository/article.repository.ts
+++ b/src/article/domain/repository/article.repository.ts
@@ -9,6 +9,7 @@ export interface ArticleRepository {
   }): Promise<Article[]>;
   findById(id: string): Promise<Article | null>;
   findByIds(articleIds: string[]): Promise<Article[]>;
+  update(article: Article): Promise<void>;
   deleteById(id: string): Promise<void>;
 }
 

--- a/src/article/domain/repository/article.repository.ts
+++ b/src/article/domain/repository/article.repository.ts
@@ -8,6 +8,7 @@ export interface ArticleRepository {
     sort?: 'createdAt' | 'scrapCount' | 'viewCount';
   }): Promise<Article[]>;
   findById(id: string): Promise<Article | null>;
+  findByIds(articleIds: string[]): Promise<Article[]>;
   deleteById(id: string): Promise<void>;
 }
 

--- a/src/article/infrastructure/repository/article.repository.impl.ts
+++ b/src/article/infrastructure/repository/article.repository.impl.ts
@@ -73,6 +73,12 @@ export class ArticleRepositoryImpl extends EntityRepository<ArticleEntity> imple
     return entities.map((entity) => ArticleMapper.toDomain(entity));
   }
 
+  async findByIds(articleIds: string[]): Promise<Article[]> {
+    const articleEntities = await this.find({ id: { $in: articleIds } }, { populate: ['tags', 'media'] });
+
+    return articleEntities.map((entity) => ArticleMapper.toDomain(entity));
+  }
+
   async deleteById(id: string): Promise<void> {
     await this.em.nativeDelete(ArticleEntity, { id });
   }

--- a/src/article/infrastructure/repository/article.repository.impl.ts
+++ b/src/article/infrastructure/repository/article.repository.impl.ts
@@ -79,6 +79,24 @@ export class ArticleRepositoryImpl extends EntityRepository<ArticleEntity> imple
     return articleEntities.map((entity) => ArticleMapper.toDomain(entity));
   }
 
+  async update(article: Article): Promise<void> {
+    await this.em.nativeUpdate(
+      ArticleEntity,
+      { id: article.id.value },
+      {
+        title: article.title,
+        organization: article.organization,
+        location: article.location,
+        description: article.description,
+        registrationUrl: article.registrationUrl,
+        startAt: article.startAt,
+        endAt: article.endAt,
+        scrapCount: article.scrapCount,
+        viewCount: article.viewCount,
+      },
+    );
+  }
+
   async deleteById(id: string): Promise<void> {
     await this.em.nativeDelete(ArticleEntity, { id });
   }

--- a/src/scrap/application/add-scrap/add-scrap.use-case.ts
+++ b/src/scrap/application/add-scrap/add-scrap.use-case.ts
@@ -28,7 +28,7 @@ export class AddScrapUseCase {
   }
 
   private async saveScrap(articleId: string, userId: string, now: Date): Promise<void> {
-    const existingScrap = await this.scrapRepository.findByArticleIdAndUserId(articleId, userId);
+    const existingScrap = await this.scrapRepository.existsByArticleIdAndUserId(articleId, userId);
     if (existingScrap) throw new ConflictException('이미 스크랩한 게시물 입니다.');
 
     const scrap = Scrap.create({

--- a/src/scrap/application/add-scrap/add-scrap.use-case.ts
+++ b/src/scrap/application/add-scrap/add-scrap.use-case.ts
@@ -1,0 +1,52 @@
+import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@mikro-orm/nestjs';
+import { ScrapEntity } from 'src/scrap/infrastructure/orm-entity/scrap.entity';
+import { AddScrapRequestDto } from './dto/add-scrap.request.dto';
+import { ScrapRepository } from 'src/scrap/domain/repository/scrap.repository';
+import { Scrap } from 'src/scrap/domain/entity/scrap';
+import { Identifier } from 'src/shared/domain/value-object/identifier';
+import { ArticleEntity } from 'src/article/infrastructure/orm-entity/article.entity';
+import { ArticleRepository } from 'src/article/domain/repository/article.repository';
+import { Transactional } from '@mikro-orm/core';
+
+@Injectable()
+export class AddScrapUseCase {
+  constructor(
+    @InjectRepository(ScrapEntity)
+    private readonly scrapRepository: ScrapRepository,
+    @InjectRepository(ArticleEntity)
+    private readonly articleRepository: ArticleRepository,
+  ) {}
+
+  @Transactional()
+  async execute(addScrapRequestDto: AddScrapRequestDto): Promise<void> {
+    const { articleId, userId } = addScrapRequestDto;
+    const now = new Date();
+
+    await this.saveScrap(articleId, userId, now);
+    await this.increaseArticleScrapCount(articleId);
+  }
+
+  private async saveScrap(articleId: string, userId: string, now: Date): Promise<void> {
+    const existingScrap = await this.scrapRepository.findByArticleIdAndUserId(articleId, userId);
+    if (existingScrap) throw new ConflictException('이미 스크랩한 게시물 입니다.');
+
+    const scrap = Scrap.create({
+      id: Identifier.create(),
+      userId: Identifier.from(userId),
+      articleId: Identifier.from(articleId),
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    await this.scrapRepository.save(scrap);
+  }
+
+  private async increaseArticleScrapCount(articleId: string): Promise<void> {
+    const article = await this.articleRepository.findById(articleId);
+    if (!article) throw new NotFoundException('존재하지 않는 게시물입니다.');
+
+    article.increaseScrapCount();
+    await this.articleRepository.update(article);
+  }
+}

--- a/src/scrap/application/add-scrap/dto/add-scrap.request.dto.ts
+++ b/src/scrap/application/add-scrap/dto/add-scrap.request.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class AddScrapRequestDto {
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({
+    description: '게시글 ID',
+    example: '244123142342',
+  })
+  articleId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({
+    description: '사용자 ID',
+    example: '23523423242',
+  })
+  userId: string;
+}

--- a/src/scrap/application/check-scrap/check-scrap.use-case.ts
+++ b/src/scrap/application/check-scrap/check-scrap.use-case.ts
@@ -1,0 +1,22 @@
+import { InjectRepository } from '@mikro-orm/nestjs';
+import { Injectable } from '@nestjs/common';
+import { ScrapRepository } from 'src/scrap/domain/repository/scrap.repository';
+import { ScrapEntity } from 'src/scrap/infrastructure/orm-entity/scrap.entity';
+import { CheckScrapRequestDto } from './dto/check-scrap.request.dto';
+import { CheckScrapResponseDto } from './dto/check-scrap.response.dto';
+
+@Injectable()
+export class CheckScrapUseCase {
+  constructor(
+    @InjectRepository(ScrapEntity)
+    private readonly scrapRepository: ScrapRepository,
+  ) {}
+
+  async execute(checkScrapRequestDto: CheckScrapRequestDto): Promise<CheckScrapResponseDto> {
+    const { articleId, userId } = checkScrapRequestDto;
+
+    const isScrapped = await this.scrapRepository.existsByArticleIdAndUserId(articleId, userId);
+
+    return { isScrapped };
+  }
+}

--- a/src/scrap/application/check-scrap/dto/check-scrap.request.dto.ts
+++ b/src/scrap/application/check-scrap/dto/check-scrap.request.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class CheckScrapRequestDto {
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({
+    description: '게시글 ID',
+    example: '244123142342',
+  })
+  articleId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({
+    description: '사용자 ID',
+    example: '23523423242',
+  })
+  userId: string;
+}

--- a/src/scrap/application/check-scrap/dto/check-scrap.response.dto.ts
+++ b/src/scrap/application/check-scrap/dto/check-scrap.response.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean, IsNotEmpty } from 'class-validator';
+
+export class CheckScrapResponseDto {
+  @IsBoolean()
+  @IsNotEmpty()
+  @ApiProperty({
+    description: '스크랩 여부',
+    example: true,
+  })
+  isScrapped: boolean;
+}

--- a/src/scrap/application/delete-scrap/delete-scrap.use-case.ts
+++ b/src/scrap/application/delete-scrap/delete-scrap.use-case.ts
@@ -24,7 +24,7 @@ export class DeleteScrapUseCase {
 
   private async decreaseArticleScrapCount(articleId: string): Promise<void> {
     const article = await this.articleRepository.findById(articleId);
-    if (!article) throw new NotFoundException('Article not found');
+    if (!article) throw new NotFoundException('해당 게시글이 존재하지 않습니다.');
 
     article.decreaseScrapCount();
     await this.articleRepository.update(article);

--- a/src/scrap/application/delete-scrap/delete-scrap.use-case.ts
+++ b/src/scrap/application/delete-scrap/delete-scrap.use-case.ts
@@ -1,0 +1,32 @@
+import { InjectRepository } from '@mikro-orm/nestjs';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { ArticleRepository } from 'src/article/domain/repository/article.repository';
+import { ArticleEntity } from 'src/article/infrastructure/orm-entity/article.entity';
+import { ScrapRepository } from 'src/scrap/domain/repository/scrap.repository';
+import { ScrapEntity } from 'src/scrap/infrastructure/orm-entity/scrap.entity';
+import { DeleteScrapRequestDto } from './dto/delete-scrap.request.dto';
+
+@Injectable()
+export class DeleteScrapUseCase {
+  constructor(
+    @InjectRepository(ScrapEntity)
+    private readonly scrapRepository: ScrapRepository,
+    @InjectRepository(ArticleEntity)
+    private readonly articleRepository: ArticleRepository,
+  ) {}
+
+  async execute(deleteScrapRequestDto: DeleteScrapRequestDto) {
+    const { articleId, userId } = deleteScrapRequestDto;
+
+    await this.scrapRepository.deleteByArticleIdAndUserId(articleId, userId);
+    await this.decreaseArticleScrapCount(articleId);
+  }
+
+  private async decreaseArticleScrapCount(articleId: string): Promise<void> {
+    const article = await this.articleRepository.findById(articleId);
+    if (!article) throw new NotFoundException('Article not found');
+
+    article.decreaseScrapCount();
+    await this.articleRepository.update(article);
+  }
+}

--- a/src/scrap/application/delete-scrap/dto/delete-scrap.request.dto.ts
+++ b/src/scrap/application/delete-scrap/dto/delete-scrap.request.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class DeleteScrapRequestDto {
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({
+    description: '게시글 ID',
+    example: '244123142342',
+  })
+  articleId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({
+    description: '사용자 ID',
+    example: '23523423242',
+  })
+  userId: string;
+}

--- a/src/scrap/application/get-my-scrap/dto/get-my-scrap.request.dto.ts
+++ b/src/scrap/application/get-my-scrap/dto/get-my-scrap.request.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class GetMyScrapRequestDto {
+  @IsString()
+  @IsNotEmpty()
+  userId: string;
+}

--- a/src/scrap/application/get-my-scrap/dto/get-my-scrap.response.dto.ts
+++ b/src/scrap/application/get-my-scrap/dto/get-my-scrap.response.dto.ts
@@ -1,0 +1,51 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsArray, IsNotEmpty, IsNumber, IsString } from 'class-validator';
+
+export class GetMyScrapResponseDto {
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({
+    description: '게시글 ID',
+    example: '11212332423r',
+  })
+  articleId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({
+    description: '게시글 제목',
+    example: '제목이얌',
+  })
+  title: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({
+    description: '주최자/기관',
+    example: '고려대학교',
+  })
+  organization: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({
+    description: '게시글 썸네일 이미지 경로',
+    example: 'https://akdsfljlsdkfa.com/thumbnail.jpg',
+  })
+  thumbnailPath: string;
+
+  @IsNumber()
+  @IsNotEmpty()
+  @ApiProperty({
+    description: '게시글 스크랩 수',
+    example: 10,
+  })
+  scrapCount: number;
+
+  @IsArray()
+  @ApiProperty({
+    description: '게시글 태그 목록',
+    example: ['태그1', '태그2'],
+  })
+  tags: string[];
+}

--- a/src/scrap/application/get-my-scrap/get-my-scrap.use-case.ts
+++ b/src/scrap/application/get-my-scrap/get-my-scrap.use-case.ts
@@ -1,0 +1,39 @@
+import { InjectRepository } from '@mikro-orm/nestjs';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { ScrapRepository } from 'src/scrap/domain/repository/scrap.repository';
+import { ScrapEntity } from 'src/scrap/infrastructure/orm-entity/scrap.entity';
+import { GetMyScrapRequestDto } from './dto/get-my-scrap.request.dto';
+import { GetMyScrapResponseDto } from './dto/get-my-scrap.response.dto';
+import { ArticleEntity } from 'src/article/infrastructure/orm-entity/article.entity';
+import { ArticleRepository } from 'src/article/domain/repository/article.repository';
+
+@Injectable()
+export class GetMyScrapUseCase {
+  constructor(
+    @InjectRepository(ScrapEntity)
+    private readonly scrapRepository: ScrapRepository,
+    @InjectRepository(ArticleEntity)
+    private readonly articleRepository: ArticleRepository,
+  ) {}
+
+  async execute(getMyScrapRequestDto: GetMyScrapRequestDto): Promise<GetMyScrapResponseDto[]> {
+    const { userId } = getMyScrapRequestDto;
+    const scraps = await this.scrapRepository.findByUserId(userId);
+    const articleIds = scraps.map((scrap) => scrap.articleId.value);
+    const articles = await this.articleRepository.findByIds(articleIds);
+
+    // 임시로직 -> 다른 방법이 있는 지 탐색 예정
+    // join vs repostiory 두 개에서 각각 가져오기
+    return articles.map((article) => {
+      if (!article) throw new NotFoundException(`해당 게시글이 존재하지 않습니다.`);
+      return {
+        articleId: article.id.value,
+        title: article.title,
+        organization: article.organization,
+        scrapCount: article.scrapCount,
+        thumbnailPath: article?.mediaIds?.[0]?.value,
+        tags: article.tags.map((tag) => tag.name),
+      };
+    });
+  }
+}

--- a/src/scrap/domain/repository/scrap.repository.ts
+++ b/src/scrap/domain/repository/scrap.repository.ts
@@ -4,6 +4,7 @@ export interface ScrapRepository {
   save(scrap: Scrap): Promise<void>;
   findByUserId(userId: string): Promise<Scrap[]>;
   findByArticleIdAndUserId(articleId: string, userId: string): Promise<Scrap | null>;
+  existsByArticleIdAndUserId(articleId: string, userId: string): Promise<boolean>;
 }
 
 export const SCRAP_REPOSITORY = Symbol('SCRAP_REPOSITORY');

--- a/src/scrap/domain/repository/scrap.repository.ts
+++ b/src/scrap/domain/repository/scrap.repository.ts
@@ -5,6 +5,7 @@ export interface ScrapRepository {
   findByUserId(userId: string): Promise<Scrap[]>;
   findByArticleIdAndUserId(articleId: string, userId: string): Promise<Scrap | null>;
   existsByArticleIdAndUserId(articleId: string, userId: string): Promise<boolean>;
+  deleteByArticleIdAndUserId(articleId: string, userId: string): Promise<void>;
 }
 
 export const SCRAP_REPOSITORY = Symbol('SCRAP_REPOSITORY');

--- a/src/scrap/domain/repository/scrap.repository.ts
+++ b/src/scrap/domain/repository/scrap.repository.ts
@@ -2,6 +2,7 @@ import { Scrap } from '../entity/scrap';
 
 export interface ScrapRepository {
   save(scrap: Scrap): Promise<void>;
+  findByUserId(userId: string): Promise<Scrap[]>;
 }
 
 export const SCRAP_REPOSITORY = Symbol('SCRAP_REPOSITORY');

--- a/src/scrap/domain/repository/scrap.repository.ts
+++ b/src/scrap/domain/repository/scrap.repository.ts
@@ -3,6 +3,7 @@ import { Scrap } from '../entity/scrap';
 export interface ScrapRepository {
   save(scrap: Scrap): Promise<void>;
   findByUserId(userId: string): Promise<Scrap[]>;
+  findByArticleIdAndUserId(articleId: string, userId: string): Promise<Scrap | null>;
 }
 
 export const SCRAP_REPOSITORY = Symbol('SCRAP_REPOSITORY');

--- a/src/scrap/infrastructure/mapper/scrap.mapper.ts
+++ b/src/scrap/infrastructure/mapper/scrap.mapper.ts
@@ -1,12 +1,11 @@
 import { Scrap } from 'src/scrap/domain/entity/scrap';
-import { ScrapEntity } from '../entity/scrap.entity';
-import { createMapper } from 'src/shared/infrastructure/mapper/base.mapper';
+import { ScrapEntity } from '../orm-entity/scrap.entity';
 import { ArticleEntity } from 'src/article/infrastructure/orm-entity/article.entity';
 import { UserEntity } from '../../../user/infrastructure/orm-entity/user.entity';
 import { Identifier } from 'src/shared/domain/value-object/identifier';
 
-export const ScrapMapper = createMapper<Scrap, ScrapEntity>(
-  (entity: ScrapEntity): Scrap => {
+export class ScrapMapper {
+  static toDomain(entity: ScrapEntity): Scrap {
     return Scrap.create({
       id: Identifier.from(entity.id),
       createdAt: entity.createdAt,
@@ -14,8 +13,9 @@ export const ScrapMapper = createMapper<Scrap, ScrapEntity>(
       articleId: Identifier.from(entity.article.id),
       userId: Identifier.from(entity.user.id),
     });
-  },
-  (domain: Scrap): ScrapEntity => {
+  }
+
+  static toEntity(domain: Scrap): ScrapEntity {
     const entity = new ScrapEntity();
     entity.id = domain.id.value;
     entity.createdAt = domain.createdAt;
@@ -24,5 +24,5 @@ export const ScrapMapper = createMapper<Scrap, ScrapEntity>(
     entity.user = { id: domain.userId.value } as UserEntity;
 
     return entity;
-  },
-);
+  }
+}

--- a/src/scrap/infrastructure/orm-entity/scrap.entity.ts
+++ b/src/scrap/infrastructure/orm-entity/scrap.entity.ts
@@ -1,10 +1,11 @@
-import { Cascade, Entity, ManyToOne } from '@mikro-orm/core';
+import { Cascade, Entity, ManyToOne, Unique } from '@mikro-orm/core';
 import { ArticleEntity } from 'src/article/infrastructure/orm-entity/article.entity';
 import { BaseEntity } from 'src/shared/infrastructure/orm-entity/base.entity';
 import { UserEntity } from '../../../user/infrastructure/orm-entity/user.entity';
 import { ScrapRepositoryImpl } from '../repository/scrap.repository.impl';
 
 @Entity({ tableName: 'scrap', repository: () => ScrapRepositoryImpl })
+@Unique({ properties: ['article', 'user'] })
 export class ScrapEntity extends BaseEntity {
   @ManyToOne(() => ArticleEntity, { cascade: [Cascade.REMOVE] })
   article: ArticleEntity;

--- a/src/scrap/infrastructure/orm-entity/scrap.entity.ts
+++ b/src/scrap/infrastructure/orm-entity/scrap.entity.ts
@@ -1,4 +1,4 @@
-import { Cascade, Entity, ManyToOne, Unique } from '@mikro-orm/core';
+import { Entity, ManyToOne, Unique } from '@mikro-orm/core';
 import { ArticleEntity } from 'src/article/infrastructure/orm-entity/article.entity';
 import { BaseEntity } from 'src/shared/infrastructure/orm-entity/base.entity';
 import { UserEntity } from '../../../user/infrastructure/orm-entity/user.entity';
@@ -7,9 +7,9 @@ import { ScrapRepositoryImpl } from '../repository/scrap.repository.impl';
 @Entity({ tableName: 'scrap', repository: () => ScrapRepositoryImpl })
 @Unique({ properties: ['article', 'user'] })
 export class ScrapEntity extends BaseEntity {
-  @ManyToOne(() => ArticleEntity, { cascade: [Cascade.REMOVE] })
+  @ManyToOne(() => ArticleEntity, { deleteRule: 'cascade' })
   article: ArticleEntity;
 
-  @ManyToOne(() => UserEntity, { cascade: [Cascade.REMOVE] })
+  @ManyToOne(() => UserEntity, { deleteRule: 'cascade' })
   user: UserEntity;
 }

--- a/src/scrap/infrastructure/orm-entity/scrap.entity.ts
+++ b/src/scrap/infrastructure/orm-entity/scrap.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, ManyToOne } from '@mikro-orm/core';
+import { Cascade, Entity, ManyToOne } from '@mikro-orm/core';
 import { ArticleEntity } from 'src/article/infrastructure/orm-entity/article.entity';
 import { BaseEntity } from 'src/shared/infrastructure/orm-entity/base.entity';
 import { UserEntity } from '../../../user/infrastructure/orm-entity/user.entity';
@@ -6,9 +6,9 @@ import { ScrapRepositoryImpl } from '../repository/scrap.repository.impl';
 
 @Entity({ tableName: 'scrap', repository: () => ScrapRepositoryImpl })
 export class ScrapEntity extends BaseEntity {
-  @ManyToOne(() => ArticleEntity)
+  @ManyToOne(() => ArticleEntity, { cascade: [Cascade.REMOVE] })
   article: ArticleEntity;
 
-  @ManyToOne(() => UserEntity)
+  @ManyToOne(() => UserEntity, { cascade: [Cascade.REMOVE] })
   user: UserEntity;
 }

--- a/src/scrap/infrastructure/repository/scrap.repository.impl.ts
+++ b/src/scrap/infrastructure/repository/scrap.repository.impl.ts
@@ -3,6 +3,7 @@ import { Scrap } from 'src/scrap/domain/entity/scrap';
 import { ScrapRepository } from 'src/scrap/domain/repository/scrap.repository';
 import { ScrapMapper } from '../mapper/scrap.mapper';
 import { ScrapEntity } from '../orm-entity/scrap.entity';
+import { NotFoundException } from '@nestjs/common';
 
 export class ScrapRepositoryImpl extends EntityRepository<ScrapEntity> implements ScrapRepository {
   async save(userScrap: Scrap): Promise<void> {
@@ -27,5 +28,12 @@ export class ScrapRepositoryImpl extends EntityRepository<ScrapEntity> implement
     const exists = await this.count({ article: { id: articleId }, user: { id: userId } });
 
     return exists > 0;
+  }
+
+  async deleteByArticleIdAndUserId(articleId: string, userId: string): Promise<void> {
+    const scrapEntity = await this.findOne({ article: { id: articleId }, user: { id: userId } });
+    if (!scrapEntity) throw new NotFoundException('스크랩이 존재하지 않습니다.');
+
+    await this.em.removeAndFlush(scrapEntity);
   }
 }

--- a/src/scrap/infrastructure/repository/scrap.repository.impl.ts
+++ b/src/scrap/infrastructure/repository/scrap.repository.impl.ts
@@ -22,4 +22,10 @@ export class ScrapRepositoryImpl extends EntityRepository<ScrapEntity> implement
 
     return ScrapMapper.toDomain(scrapEntity);
   }
+
+  async existsByArticleIdAndUserId(articleId: string, userId: string): Promise<boolean> {
+    const exists = await this.count({ article: { id: articleId }, user: { id: userId } });
+
+    return exists > 0;
+  }
 }

--- a/src/scrap/infrastructure/repository/scrap.repository.impl.ts
+++ b/src/scrap/infrastructure/repository/scrap.repository.impl.ts
@@ -2,10 +2,17 @@ import { EntityRepository } from '@mikro-orm/mysql';
 import { Scrap } from 'src/scrap/domain/entity/scrap';
 import { ScrapRepository } from 'src/scrap/domain/repository/scrap.repository';
 import { ScrapMapper } from '../mapper/scrap.mapper';
+import { ScrapEntity } from '../orm-entity/scrap.entity';
 
-export class ScrapRepositoryImpl extends EntityRepository<Scrap> implements ScrapRepository {
+export class ScrapRepositoryImpl extends EntityRepository<ScrapEntity> implements ScrapRepository {
   async save(userScrap: Scrap): Promise<void> {
     const userScrapEntity = ScrapMapper.toEntity(userScrap);
     await this.em.persistAndFlush(userScrapEntity);
+  }
+
+  async findByUserId(userId: string): Promise<Scrap[]> {
+    const scrapEntities = await this.find({ user: { id: userId } }, { orderBy: { updatedAt: 'DESC' } });
+
+    return scrapEntities.map((entity) => ScrapMapper.toDomain(entity));
   }
 }

--- a/src/scrap/infrastructure/repository/scrap.repository.impl.ts
+++ b/src/scrap/infrastructure/repository/scrap.repository.impl.ts
@@ -15,4 +15,11 @@ export class ScrapRepositoryImpl extends EntityRepository<ScrapEntity> implement
 
     return scrapEntities.map((entity) => ScrapMapper.toDomain(entity));
   }
+
+  async findByArticleIdAndUserId(articleId: string, userId: string): Promise<Scrap | null> {
+    const scrapEntity = await this.findOne({ article: { id: articleId }, user: { id: userId } });
+    if (!scrapEntity) return null;
+
+    return ScrapMapper.toDomain(scrapEntity);
+  }
 }

--- a/src/scrap/presentation/scrap.controller.ts
+++ b/src/scrap/presentation/scrap.controller.ts
@@ -1,14 +1,18 @@
-import { Controller, Get, Patch, UseGuards } from '@nestjs/common';
+import { Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { ApiTags } from '@nestjs/swagger';
 import { GetMyScrapUseCase } from '../application/get-my-scrap/get-my-scrap.use-case';
 import { User, UserPayload } from 'src/shared/presentation/decorator/user.decorator';
 import { ScrapDocs } from './scrap.docs';
+import { AddScrapUseCase } from '../application/add-scrap/add-scrap.use-case';
 
 @ApiTags('scrap')
 @Controller('scrap')
 export class ScrapController {
-  constructor(private readonly getMyScrapUseCase: GetMyScrapUseCase) {}
+  constructor(
+    private readonly getMyScrapUseCase: GetMyScrapUseCase,
+    private readonly addScrapUseCase: AddScrapUseCase,
+  ) {}
 
   @Get()
   @UseGuards(AuthGuard('jwt-access'))
@@ -17,6 +21,9 @@ export class ScrapController {
     return await this.getMyScrapUseCase.execute({ userId: user.userId });
   }
 
-  @Patch()
-  async updateScrap() {}
+  @Post(':id')
+  @UseGuards(AuthGuard('jwt-access'))
+  async addScrap(@Param('id') articleId: string, @User() user: UserPayload) {
+    await this.addScrapUseCase.execute({ articleId, userId: user.userId });
+  }
 }

--- a/src/scrap/presentation/scrap.controller.ts
+++ b/src/scrap/presentation/scrap.controller.ts
@@ -1,12 +1,20 @@
-import { Controller, Get, Patch } from '@nestjs/common';
+import { Controller, Get, Patch, UseGuards } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
 import { ApiTags } from '@nestjs/swagger';
+import { GetMyScrapUseCase } from '../application/get-my-scrap/get-my-scrap.use-case';
+import { User, UserPayload } from 'src/shared/presentation/decorator/user.decorator';
 
 @ApiTags('scrap')
 @Controller('scrap')
 export class ScrapController {
-  @Get('scrap')
-  async getMyScrap() {}
+  constructor(private readonly getMyScrapUseCase: GetMyScrapUseCase) {}
 
-  @Patch('scrap')
+  @Get()
+  @UseGuards(AuthGuard('jwt-access'))
+  async getMyScrap(@User() user: UserPayload) {
+    return await this.getMyScrapUseCase.execute({ userId: user.userId });
+  }
+
+  @Patch()
   async updateScrap() {}
 }

--- a/src/scrap/presentation/scrap.controller.ts
+++ b/src/scrap/presentation/scrap.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
+import { Controller, Delete, Get, Param, Post, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { ApiTags } from '@nestjs/swagger';
 import { GetMyScrapUseCase } from '../application/get-my-scrap/get-my-scrap.use-case';
@@ -6,6 +6,7 @@ import { User, UserPayload } from 'src/shared/presentation/decorator/user.decora
 import { ScrapDocs } from './scrap.docs';
 import { AddScrapUseCase } from '../application/add-scrap/add-scrap.use-case';
 import { CheckScrapUseCase } from '../application/check-scrap/check-scrap.use-case';
+import { DeleteScrapUseCase } from '../application/delete-scrap/delete-scrap.use-case';
 
 @ApiTags('scrap')
 @Controller('scrap')
@@ -14,6 +15,7 @@ export class ScrapController {
     private readonly getMyScrapUseCase: GetMyScrapUseCase,
     private readonly addScrapUseCase: AddScrapUseCase,
     private readonly checkScrapUseCase: CheckScrapUseCase,
+    private readonly deleteScrapUseCase: DeleteScrapUseCase,
   ) {}
 
   @Get()
@@ -35,5 +37,11 @@ export class ScrapController {
   @ScrapDocs('addScrap')
   async addScrap(@Param('id') articleId: string, @User() user: UserPayload) {
     await this.addScrapUseCase.execute({ articleId, userId: user.userId });
+  }
+
+  @Delete(':id')
+  @UseGuards(AuthGuard('jwt-access'))
+  async deleteScrap(@Param('id') articleId: string, @User() user: UserPayload) {
+    await this.deleteScrapUseCase.execute({ articleId, userId: user.userId });
   }
 }

--- a/src/scrap/presentation/scrap.controller.ts
+++ b/src/scrap/presentation/scrap.controller.ts
@@ -41,6 +41,7 @@ export class ScrapController {
 
   @Delete(':id')
   @UseGuards(AuthGuard('jwt-access'))
+  @ScrapDocs('deleteScrap')
   async deleteScrap(@Param('id') articleId: string, @User() user: UserPayload) {
     await this.deleteScrapUseCase.execute({ articleId, userId: user.userId });
   }

--- a/src/scrap/presentation/scrap.controller.ts
+++ b/src/scrap/presentation/scrap.controller.ts
@@ -3,6 +3,7 @@ import { AuthGuard } from '@nestjs/passport';
 import { ApiTags } from '@nestjs/swagger';
 import { GetMyScrapUseCase } from '../application/get-my-scrap/get-my-scrap.use-case';
 import { User, UserPayload } from 'src/shared/presentation/decorator/user.decorator';
+import { ScrapDocs } from './scrap.docs';
 
 @ApiTags('scrap')
 @Controller('scrap')
@@ -11,6 +12,7 @@ export class ScrapController {
 
   @Get()
   @UseGuards(AuthGuard('jwt-access'))
+  @ScrapDocs('getMyScrap')
   async getMyScrap(@User() user: UserPayload) {
     return await this.getMyScrapUseCase.execute({ userId: user.userId });
   }

--- a/src/scrap/presentation/scrap.controller.ts
+++ b/src/scrap/presentation/scrap.controller.ts
@@ -5,6 +5,7 @@ import { GetMyScrapUseCase } from '../application/get-my-scrap/get-my-scrap.use-
 import { User, UserPayload } from 'src/shared/presentation/decorator/user.decorator';
 import { ScrapDocs } from './scrap.docs';
 import { AddScrapUseCase } from '../application/add-scrap/add-scrap.use-case';
+import { CheckScrapUseCase } from '../application/check-scrap/check-scrap.use-case';
 
 @ApiTags('scrap')
 @Controller('scrap')
@@ -12,6 +13,7 @@ export class ScrapController {
   constructor(
     private readonly getMyScrapUseCase: GetMyScrapUseCase,
     private readonly addScrapUseCase: AddScrapUseCase,
+    private readonly checkScrapUseCase: CheckScrapUseCase,
   ) {}
 
   @Get()
@@ -19,6 +21,12 @@ export class ScrapController {
   @ScrapDocs('getMyScrap')
   async getMyScrap(@User() user: UserPayload) {
     return await this.getMyScrapUseCase.execute({ userId: user.userId });
+  }
+
+  @Get('article/:id')
+  @UseGuards(AuthGuard('jwt-access'))
+  async checkScrap(@Param('id') articleId: string, @User() user: UserPayload) {
+    return await this.checkScrapUseCase.execute({ articleId, userId: user.userId });
   }
 
   @Post(':id')

--- a/src/scrap/presentation/scrap.controller.ts
+++ b/src/scrap/presentation/scrap.controller.ts
@@ -25,12 +25,14 @@ export class ScrapController {
 
   @Get('article/:id')
   @UseGuards(AuthGuard('jwt-access'))
+  @ScrapDocs('checkScrap')
   async checkScrap(@Param('id') articleId: string, @User() user: UserPayload) {
     return await this.checkScrapUseCase.execute({ articleId, userId: user.userId });
   }
 
   @Post(':id')
   @UseGuards(AuthGuard('jwt-access'))
+  @ScrapDocs('addScrap')
   async addScrap(@Param('id') articleId: string, @User() user: UserPayload) {
     await this.addScrapUseCase.execute({ articleId, userId: user.userId });
   }

--- a/src/scrap/presentation/scrap.docs.ts
+++ b/src/scrap/presentation/scrap.docs.ts
@@ -1,9 +1,15 @@
 import { applyDecorators } from '@nestjs/common';
-import { ApiNotFoundResponse, ApiOkResponse, ApiOperation, ApiUnauthorizedResponse } from '@nestjs/swagger';
+import {
+  ApiConflictResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
 import { createDocs } from 'src/shared/presentation/docs/base.docs';
 import { GetMyScrapResponseDto } from '../application/get-my-scrap/dto/get-my-scrap.response.dto';
 
-export type ScrapEndpoint = 'getMyScrap';
+export type ScrapEndpoint = 'getMyScrap' | 'addScrap';
 
 export const ScrapDocs = createDocs<ScrapEndpoint>({
   getMyScrap: () =>
@@ -22,6 +28,25 @@ export const ScrapDocs = createDocs<ScrapEndpoint>({
       }),
       ApiNotFoundResponse({
         description: '해당 게시글이 존재하지 않습니다.',
+      }),
+    ),
+  addScrap: () =>
+    applyDecorators(
+      ApiOperation({
+        summary: '스크랩 추가',
+        description: '게시글을 스크랩합니다.',
+      }),
+      ApiOkResponse({
+        description: '스크랩 추가 성공',
+      }),
+      ApiUnauthorizedResponse({
+        description: '유효하지 않은 access token',
+      }),
+      ApiNotFoundResponse({
+        description: '해당 게시글이 존재하지 않습니다.',
+      }),
+      ApiConflictResponse({
+        description: '이미 스크랩한 게시글입니다.',
       }),
     ),
 });

--- a/src/scrap/presentation/scrap.docs.ts
+++ b/src/scrap/presentation/scrap.docs.ts
@@ -4,13 +4,14 @@ import {
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
+  ApiParam,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 import { createDocs } from 'src/shared/presentation/docs/base.docs';
 import { GetMyScrapResponseDto } from '../application/get-my-scrap/dto/get-my-scrap.response.dto';
 import { CheckScrapResponseDto } from '../application/check-scrap/dto/check-scrap.response.dto';
 
-export type ScrapEndpoint = 'getMyScrap' | 'addScrap' | 'checkScrap';
+export type ScrapEndpoint = 'getMyScrap' | 'addScrap' | 'checkScrap' | 'deleteScrap';
 
 export const ScrapDocs = createDocs<ScrapEndpoint>({
   getMyScrap: () =>
@@ -37,6 +38,10 @@ export const ScrapDocs = createDocs<ScrapEndpoint>({
         summary: '스크랩 추가',
         description: '게시글을 스크랩합니다.',
       }),
+      ApiParam({
+        name: 'id',
+        description: '게시글 ID',
+      }),
       ApiOkResponse({
         description: '스크랩 추가 성공',
       }),
@@ -56,6 +61,10 @@ export const ScrapDocs = createDocs<ScrapEndpoint>({
         summary: '스크랩 여부 확인',
         description: '게시글이 스크랩되었는지 확인',
       }),
+      ApiParam({
+        name: 'id',
+        description: '게시글 ID',
+      }),
       ApiOkResponse({
         description: '스크랩 여부 확인 성공',
         type: CheckScrapResponseDto,
@@ -65,6 +74,29 @@ export const ScrapDocs = createDocs<ScrapEndpoint>({
       }),
       ApiNotFoundResponse({
         description: '해당 게시글이 존재하지 않습니다.',
+      }),
+    ),
+  deleteScrap: () =>
+    applyDecorators(
+      ApiOperation({
+        summary: '스크랩 삭제',
+        description: '게시글 스크랩 삭제',
+      }),
+      ApiParam({
+        name: 'id',
+        description: '게시글 ID',
+      }),
+      ApiOkResponse({
+        description: '스크랩 삭제 성공',
+      }),
+      ApiUnauthorizedResponse({
+        description: '유효하지 않은 access token',
+      }),
+      ApiNotFoundResponse({
+        description: '해당 게시글이 존재하지 않습니다.',
+      }),
+      ApiNotFoundResponse({
+        description: '해당 게시글에 대한 스크랩이 존재하지 않습니다.',
       }),
     ),
 });

--- a/src/scrap/presentation/scrap.docs.ts
+++ b/src/scrap/presentation/scrap.docs.ts
@@ -1,0 +1,27 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiNotFoundResponse, ApiOkResponse, ApiOperation, ApiUnauthorizedResponse } from '@nestjs/swagger';
+import { createDocs } from 'src/shared/presentation/docs/base.docs';
+import { GetMyScrapResponseDto } from '../application/get-my-scrap/dto/get-my-scrap.response.dto';
+
+export type ScrapEndpoint = 'getMyScrap';
+
+export const ScrapDocs = createDocs<ScrapEndpoint>({
+  getMyScrap: () =>
+    applyDecorators(
+      ApiOperation({
+        summary: '본인 스크랩 목록 조회',
+        description: '사용자가 스크랩한 게시글 목록 조회.',
+      }),
+      ApiOkResponse({
+        description: '스크랩 목록 조회 성공',
+        type: GetMyScrapResponseDto,
+        isArray: true,
+      }),
+      ApiUnauthorizedResponse({
+        description: '유효하지 않은 access token',
+      }),
+      ApiNotFoundResponse({
+        description: '해당 게시글이 존재하지 않습니다.',
+      }),
+    ),
+});

--- a/src/scrap/presentation/scrap.docs.ts
+++ b/src/scrap/presentation/scrap.docs.ts
@@ -8,8 +8,9 @@ import {
 } from '@nestjs/swagger';
 import { createDocs } from 'src/shared/presentation/docs/base.docs';
 import { GetMyScrapResponseDto } from '../application/get-my-scrap/dto/get-my-scrap.response.dto';
+import { CheckScrapResponseDto } from '../application/check-scrap/dto/check-scrap.response.dto';
 
-export type ScrapEndpoint = 'getMyScrap' | 'addScrap';
+export type ScrapEndpoint = 'getMyScrap' | 'addScrap' | 'checkScrap';
 
 export const ScrapDocs = createDocs<ScrapEndpoint>({
   getMyScrap: () =>
@@ -47,6 +48,23 @@ export const ScrapDocs = createDocs<ScrapEndpoint>({
       }),
       ApiConflictResponse({
         description: '이미 스크랩한 게시글입니다.',
+      }),
+    ),
+  checkScrap: () =>
+    applyDecorators(
+      ApiOperation({
+        summary: '스크랩 여부 확인',
+        description: '게시글이 스크랩되었는지 확인',
+      }),
+      ApiOkResponse({
+        description: '스크랩 여부 확인 성공',
+        type: CheckScrapResponseDto,
+      }),
+      ApiUnauthorizedResponse({
+        description: '유효하지 않은 access token',
+      }),
+      ApiNotFoundResponse({
+        description: '해당 게시글이 존재하지 않습니다.',
       }),
     ),
 });

--- a/src/scrap/scrap.module.ts
+++ b/src/scrap/scrap.module.ts
@@ -1,18 +1,28 @@
 import { Module } from '@nestjs/common';
 import { ScrapController } from './presentation/scrap.controller';
 import { MikroOrmModule } from '@mikro-orm/nestjs';
-import { ScrapEntity } from 'src/scrap/infrastructure/entity/scrap.entity';
+import { ScrapEntity } from 'src/scrap/infrastructure/orm-entity/scrap.entity';
 import { SCRAP_REPOSITORY } from './domain/repository/scrap.repository';
 import { ScrapRepositoryImpl } from './infrastructure/repository/scrap.repository.impl';
 import { UserEntity } from 'src/user/infrastructure/orm-entity/user.entity';
 import { ArticleEntity } from 'src/article/infrastructure/orm-entity/article.entity';
+import { GetMyScrapUseCase } from './application/get-my-scrap/get-my-scrap.use-case';
+import { ARTICLE_REPOSITORY } from 'src/article/domain/repository/article.repository';
+import { ArticleRepositoryImpl } from 'src/article/infrastructure/repository/article.repository.impl';
+
+const useCases = [GetMyScrapUseCase];
 
 @Module({
   imports: [MikroOrmModule.forFeature([ScrapEntity, UserEntity, ArticleEntity])],
   providers: [
+    ...useCases,
     {
       provide: SCRAP_REPOSITORY,
       useClass: ScrapRepositoryImpl,
+    },
+    {
+      provide: ARTICLE_REPOSITORY,
+      useClass: ArticleRepositoryImpl,
     },
   ],
   controllers: [ScrapController],

--- a/src/scrap/scrap.module.ts
+++ b/src/scrap/scrap.module.ts
@@ -9,8 +9,9 @@ import { ArticleEntity } from 'src/article/infrastructure/orm-entity/article.ent
 import { GetMyScrapUseCase } from './application/get-my-scrap/get-my-scrap.use-case';
 import { ARTICLE_REPOSITORY } from 'src/article/domain/repository/article.repository';
 import { ArticleRepositoryImpl } from 'src/article/infrastructure/repository/article.repository.impl';
+import { AddScrapUseCase } from './application/add-scrap/add-scrap.use-case';
 
-const useCases = [GetMyScrapUseCase];
+const useCases = [GetMyScrapUseCase, AddScrapUseCase];
 
 @Module({
   imports: [MikroOrmModule.forFeature([ScrapEntity, UserEntity, ArticleEntity])],

--- a/src/scrap/scrap.module.ts
+++ b/src/scrap/scrap.module.ts
@@ -11,8 +11,9 @@ import { ARTICLE_REPOSITORY } from 'src/article/domain/repository/article.reposi
 import { ArticleRepositoryImpl } from 'src/article/infrastructure/repository/article.repository.impl';
 import { AddScrapUseCase } from './application/add-scrap/add-scrap.use-case';
 import { CheckScrapUseCase } from './application/check-scrap/check-scrap.use-case';
+import { DeleteScrapUseCase } from './application/delete-scrap/delete-scrap.use-case';
 
-const useCases = [GetMyScrapUseCase, AddScrapUseCase, CheckScrapUseCase];
+const useCases = [GetMyScrapUseCase, AddScrapUseCase, CheckScrapUseCase, DeleteScrapUseCase];
 
 @Module({
   imports: [MikroOrmModule.forFeature([ScrapEntity, UserEntity, ArticleEntity])],

--- a/src/scrap/scrap.module.ts
+++ b/src/scrap/scrap.module.ts
@@ -10,8 +10,9 @@ import { GetMyScrapUseCase } from './application/get-my-scrap/get-my-scrap.use-c
 import { ARTICLE_REPOSITORY } from 'src/article/domain/repository/article.repository';
 import { ArticleRepositoryImpl } from 'src/article/infrastructure/repository/article.repository.impl';
 import { AddScrapUseCase } from './application/add-scrap/add-scrap.use-case';
+import { CheckScrapUseCase } from './application/check-scrap/check-scrap.use-case';
 
-const useCases = [GetMyScrapUseCase, AddScrapUseCase];
+const useCases = [GetMyScrapUseCase, AddScrapUseCase, CheckScrapUseCase];
 
 @Module({
   imports: [MikroOrmModule.forFeature([ScrapEntity, UserEntity, ArticleEntity])],

--- a/src/user/infrastructure/orm-entity/user.entity.ts
+++ b/src/user/infrastructure/orm-entity/user.entity.ts
@@ -2,7 +2,7 @@ import { Cascade, Collection, Entity, OneToMany, OneToOne, Property } from '@mik
 import { Role } from 'src/user/domain/value-object/role.enum';
 import { AuthEntity } from 'src/auth/infrastructure/orm-entity/auth.entity';
 import { BaseEntity } from 'src/shared/infrastructure/orm-entity/base.entity';
-import { ScrapEntity } from '../../../scrap/infrastructure/entity/scrap.entity';
+import { ScrapEntity } from '../../../scrap/infrastructure/orm-entity/scrap.entity';
 import { UserRepositoryImpl } from '../repository/user.repository.impl';
 
 @Entity({ tableName: 'user', repository: () => UserRepositoryImpl })

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -4,7 +4,7 @@ import { USER_REPOSITORY } from './domain/repository/user.repository';
 import { MikroOrmModule } from '@mikro-orm/nestjs';
 import { UserEntity } from './infrastructure/orm-entity/user.entity';
 import { CreateUserUseCase } from './application/create-user/create-user.use-case';
-import { ScrapEntity } from '../scrap/infrastructure/entity/scrap.entity';
+import { ScrapEntity } from '../scrap/infrastructure/orm-entity/scrap.entity';
 import { UserController } from './presentation/user.controller';
 import { GetMyInfoUseCase } from './application/get-my-info/get-my-info.use-case';
 import { DeleteMyInfoUseCase } from './application/delete-my-info/delete-my-info.use-case';


### PR DESCRIPTION
**작업내용**
- 스크랩 목록 조회 api 구현
- article repository에 findByIds 구현
- scrap repository 이용 해서 userId와 일치하는 scrap entity 전부 가져오기
  => article repository findByIds 이용해서 article 메타 데이터 가져오기

---------------------------------------------------------------------------------
**작업내용**
- 스크랩하기 api 구현
- article repository에 update 구현 및 article domain entity에 scrap count 증가 구현(스크랩시 scrap count 증가를 위해)
- 스크랩 시 스크랩 db 저장, article scrap count 증가

---------------------------------------------------------------------------------
**작업내용**
- 스크랩 삭제 api 구현
- article domain entity에 scrap count 감소 구현(스크랩 취소 시 scrap count 감소를 위해)
- 스크랩 취소 시, 스크랩 db 삭제, article scrap count 감소

--------------------------------------------------------------------------------
**작업내용**
- 게시물 스크랩 여부 조회 api 구현
- 기존 명세서에는 존재하지 않았지만, 특정 게시글에 접속했을 때, 해당 게시글의 스크랩 여부를 확인하는 api가 필요하여 추가


※
- 스크랩 된 게시글(article) 목록 조회할 때, join 사용할 지, 현재 방법(위에 써져 있는 방법) 사용할 지 생각해봐야 함.
아니면 join query만 repository를 따로 파는 방법도 있다고 함.
- update를 native update 사용 중인데, em 을 이용한 flush 방법도 고려해볼 필요가 있음.
- api endpoint를 article/:id/scrap <- 이게 더 나은 지 고민중