### PR TITLE
행사 목록 조회 에러 수정

### DIFF
--- a/src/article/query/infrastructure/article.query.repository.impl.ts
+++ b/src/article/query/infrastructure/article.query.repository.impl.ts
@@ -109,7 +109,11 @@ export class ArticleQueryRepositoryImpl implements ArticleQueryRepository {
     }
 
     // 정렬
-    query.orderBy({ [`a.${sortBy}`]: 'DESC' }); // 페이징
+    if (sortBy) {
+      query.orderBy({ [`a.${sortBy}`]: 'DESC' });
+    } else {
+      query.orderBy({ 'a.createdAt': 'DESC' }); // 기본 정렬은 생성일 기준
+    }
 
     // query.limit(limit).offset((page - 1) * limit);
 

--- a/src/article/query/infrastructure/article.query.repository.impl.ts
+++ b/src/article/query/infrastructure/article.query.repository.impl.ts
@@ -95,18 +95,25 @@ export class ArticleQueryRepositoryImpl implements ArticleQueryRepository {
       .groupBy('a.id');
 
     if (tags && tags.length > 0) {
-      query.andWhere({ tags: { name: { $in: tags } } });
+      const placeholders = tags.map(() => '?').join(',');
+      query.andWhere(
+        `a.id IN (
+          SELECT DISTINCT a2.id 
+          FROM article a2 
+          INNER JOIN article_tags at2 ON a2.id = at2.article_entity_id 
+          INNER JOIN tag t2 ON at2.tag_entity_id = t2.id 
+          WHERE t2.name IN (${placeholders})
+        )`,
+        tags,
+      );
     }
 
-    // 조건: isFinished → endAt < now
-    if (typeof isFinished === 'boolean') {
+    // 조건: isFinished가 false일 때만 진행 중인 것들만 필터링
+    if (isFinished === false) {
       const now = new Date();
-      if (isFinished) {
-        query.andWhere({ endAt: { $lt: now } });
-      } else {
-        query.andWhere({ endAt: { $gte: now } });
-      }
+      query.andWhere({ endAt: { $gte: now } }); // 종료되지 않은 것만
     }
+    // isFinished가 true이거나 undefined면 모든 것을 조회 (필터링 없음)
 
     // 정렬
     if (sortBy) {


### PR DESCRIPTION
- 행사 목록 조회의 기본 정렬을 생성일 순으로 변경
- 행사 목록 조회에서 태그가 전부 다 나오지 않고 tags 쿼리에 넣은 태그만 나오는 현상 수정
- isFinished가 true이면 종료된 것까지 포함해서, false이면 종료되지 않은 것만 출력하도록 수정