### PR TITLE
Fix/article

### DIFF
--- a/src/article/command/application/update-article/dto/update-article.request.dto.ts
+++ b/src/article/command/application/update-article/dto/update-article.request.dto.ts
@@ -76,15 +76,4 @@ export class UpdateArticleRequestDto {
   @IsOptional()
   @Type(() => String)
   tags?: string[];
-
-  @ApiProperty({
-    description: '첨부할 미디어 파일 ID 목록',
-    example: ['media-id-1', 'media-id-2'],
-    type: [String],
-    required: false,
-  })
-  @IsArray()
-  @IsOptional()
-  @Type(() => String)
-  mediaIds?: string[];
 }

--- a/src/article/command/application/update-article/update-article.use-case.ts
+++ b/src/article/command/application/update-article/update-article.use-case.ts
@@ -50,12 +50,6 @@ export class UpdateArticleUseCase {
       article.setTags(tags);
     }
 
-    // 미디어 처리
-    if (reqDto.mediaIds !== undefined && reqDto.mediaIds.length > 0) {
-      // 삭제할 미디어 ID들을 직접 삭제
-      await this.mediaCommandRepo.deleteByIds(reqDto.mediaIds);
-    }
-
     // Article 업데이트
     article.update({
       title: reqDto.title,

--- a/src/article/query/infrastructure/article.query.repository.impl.ts
+++ b/src/article/query/infrastructure/article.query.repository.impl.ts
@@ -54,6 +54,7 @@ export class ArticleQueryRepositoryImpl implements ArticleQueryRepository {
       .select(['m.media_path as mediaPath'])
       .leftJoin('a.media', 'm')
       .where({ id: id })
+      .andWhere('m.order != 0')
       .orderBy({ 'm.order': 'ASC' })
       .execute<{ mediaPath: string }[]>();
 

--- a/src/media/command/application/create/create.use-case.ts
+++ b/src/media/command/application/create/create.use-case.ts
@@ -17,20 +17,19 @@ export class CreateMediaUseCase {
     const { articleId, thumbnailInfo, fileInfoList } = reqDto;
     const mediaList: Media[] = [];
 
-    mediaList.push(this.createMedia(articleId, thumbnailInfo.objectKey, 0));
+    mediaList.push(this.createMedia(articleId, thumbnailInfo.imageUrl, 0));
 
     for (let i = 0; i < fileInfoList.length; i++) {
       const fileInfo = fileInfoList[i];
 
-      mediaList.push(this.createMedia(articleId, fileInfo.objectKey, i + 1));
+      mediaList.push(this.createMedia(articleId, fileInfo.imageUrl, i + 1));
     }
 
     await this.mediaCommandRepository.saveAll(mediaList);
   }
 
-  private createMedia(articleId: string, objectKey: string, order: number): Media {
+  private createMedia(articleId: string, imageUrl: string, order: number): Media {
     const mediaId = Identifier.create();
-    const imageUrl = this.s3Adapter.generateImageUrl(objectKey);
 
     return Media.create({
       id: mediaId,

--- a/src/media/command/application/create/dto/create.request.dto.ts
+++ b/src/media/command/application/create/dto/create.request.dto.ts
@@ -2,9 +2,13 @@ import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { IsArray, IsNotEmpty, IsString, ValidateNested } from 'class-validator';
 
-class FileInfo {
+class ImageUrlInfo {
   @IsString()
   @IsNotEmpty()
+  @ApiProperty({
+    description: '이미지 경로',
+    example: 'https://aaaaaaa.com/aaaa.png',
+  })
   imageUrl: string;
 }
 
@@ -19,16 +23,20 @@ export class CreateMediaRequestDto {
 
   @IsNotEmpty()
   @ValidateNested({ each: true })
-  @Type(() => FileInfo)
-  thumbnailInfo: FileInfo;
+  @Type(() => ImageUrlInfo)
+  @ApiProperty({
+    description: '썸네일 정보',
+    type: ImageUrlInfo,
+  })
+  thumbnailInfo: ImageUrlInfo;
 
   @IsArray()
   @IsNotEmpty()
   @ValidateNested({ each: true })
-  @Type(() => FileInfo)
+  @Type(() => ImageUrlInfo)
   @ApiProperty({
     description: '파일 정보 목록',
-    example: [{ objectKey: '/images/1/afdadf' }],
+    type: ImageUrlInfo,
   })
-  fileInfoList: FileInfo[];
+  fileInfoList: ImageUrlInfo[];
 }

--- a/src/media/command/application/create/dto/create.request.dto.ts
+++ b/src/media/command/application/create/dto/create.request.dto.ts
@@ -5,7 +5,7 @@ import { IsArray, IsNotEmpty, IsString, ValidateNested } from 'class-validator';
 class FileInfo {
   @IsString()
   @IsNotEmpty()
-  objectKey: string;
+  imageUrl: string;
 }
 
 export class CreateMediaRequestDto {
@@ -28,7 +28,7 @@ export class CreateMediaRequestDto {
   @Type(() => FileInfo)
   @ApiProperty({
     description: '파일 정보 목록',
-    example: [{ fileName: 'adfaebarc.jpg', mimeType: 'image/jpeg', isThumbnail: true }],
+    example: [{ objectKey: '/images/1/afdadf' }],
   })
   fileInfoList: FileInfo[];
 }

--- a/src/media/command/application/generate-presigned-url/dto/generate-presigned-url.request.dto.ts
+++ b/src/media/command/application/generate-presigned-url/dto/generate-presigned-url.request.dto.ts
@@ -5,10 +5,18 @@ import { IsArray, IsNotEmpty, IsString, ValidateNested } from 'class-validator';
 class FileInfo {
   @IsString()
   @IsNotEmpty()
+  @ApiProperty({
+    description: '파일명',
+    example: 'aaaaaa.png',
+  })
   fileName: string;
 
   @IsString()
   @IsNotEmpty()
+  @ApiProperty({
+    description: 'mimetype',
+    example: 'image/jpg',
+  })
   mimeType: string;
 }
 
@@ -24,6 +32,10 @@ export class GeneratePresignedUrlRequestDto {
   @IsNotEmpty()
   @ValidateNested({ each: true })
   @Type(() => FileInfo)
+  @ApiProperty({
+    description: '썸네일 정보',
+    type: FileInfo,
+  })
   thumbnailInfo: FileInfo;
 
   @IsArray()
@@ -32,7 +44,7 @@ export class GeneratePresignedUrlRequestDto {
   @Type(() => FileInfo)
   @ApiProperty({
     description: '파일 정보 목록',
-    example: [{ fileName: 'adfaebarc.jpg', mimeType: 'image/jpeg', isThumbnail: true }],
+    type: [FileInfo],
   })
   fileInfoList: FileInfo[];
 }

--- a/src/media/command/application/generate-presigned-url/dto/generate-presigned-url.request.dto.ts
+++ b/src/media/command/application/generate-presigned-url/dto/generate-presigned-url.request.dto.ts
@@ -29,17 +29,15 @@ export class GeneratePresignedUrlRequestDto {
   })
   articleId: string;
 
-  @IsNotEmpty()
   @ValidateNested({ each: true })
   @Type(() => FileInfo)
   @ApiProperty({
     description: '썸네일 정보',
     type: FileInfo,
   })
-  thumbnailInfo: FileInfo;
+  thumbnailInfo?: FileInfo;
 
   @IsArray()
-  @IsNotEmpty()
   @ValidateNested({ each: true })
   @Type(() => FileInfo)
   @ApiProperty({

--- a/src/media/command/application/generate-presigned-url/dto/generate-presigned-url.response.dto.ts
+++ b/src/media/command/application/generate-presigned-url/dto/generate-presigned-url.response.dto.ts
@@ -24,7 +24,7 @@ export class GeneratePresignedUrlResponseDto {
     description: 'Article ID',
     type: PresignedUrlInfo,
   })
-  thumbnailPresignedUrl: PresignedUrlInfo;
+  thumbnailPresignedUrl?: PresignedUrlInfo;
 
   @ApiProperty({
     description: 'List of presigned URLs',

--- a/src/media/command/application/generate-presigned-url/dto/generate-presigned-url.response.dto.ts
+++ b/src/media/command/application/generate-presigned-url/dto/generate-presigned-url.response.dto.ts
@@ -14,9 +14,9 @@ export class PresignedUrlInfo {
   @IsNotEmpty()
   @ApiProperty({
     description: 'Image URL',
-    example: '/path/to/file.jpg',
+    example: 'https://aaaaa.com/path/to/file.jpg',
   })
-  objectKey: string;
+  imageUrl: string;
 }
 
 export class GeneratePresignedUrlResponseDto {

--- a/src/media/command/application/generate-presigned-url/dto/generate-presigned-url.response.dto.ts
+++ b/src/media/command/application/generate-presigned-url/dto/generate-presigned-url.response.dto.ts
@@ -22,7 +22,7 @@ export class PresignedUrlInfo {
 export class GeneratePresignedUrlResponseDto {
   @ApiProperty({
     description: 'Article ID',
-    example: '1231312124',
+    type: PresignedUrlInfo,
   })
   thumbnailPresignedUrl: PresignedUrlInfo;
 

--- a/src/media/command/application/generate-presigned-url/generate-presigned-url.use-case.ts
+++ b/src/media/command/application/generate-presigned-url/generate-presigned-url.use-case.ts
@@ -13,11 +13,10 @@ export class GeneratePresignedUrlUseCase {
     const { articleId, thumbnailInfo, fileInfoList } = generatePresignedUrlRequestDto;
     const presignedUrls: PresignedUrlInfo[] = [];
 
-    const thumbnailPresignedUrl = await this.s3Adapter.upload(
-      articleId,
-      thumbnailInfo.fileName,
-      thumbnailInfo.mimeType,
-    );
+    let thumbnailPresignedUrl: PresignedUrlInfo | undefined;
+
+    if (thumbnailInfo)
+      thumbnailPresignedUrl = await this.s3Adapter.upload(articleId, thumbnailInfo.fileName, thumbnailInfo.mimeType);
 
     for (let i = 0; i < fileInfoList.length; i++) {
       const fileInfo = fileInfoList[i];

--- a/src/media/command/application/update/dto/update.request.dto.ts
+++ b/src/media/command/application/update/dto/update.request.dto.ts
@@ -1,0 +1,34 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsArray, IsNotEmpty, IsString, ValidateNested } from 'class-validator';
+
+class FileInfo {
+  @IsString()
+  @IsNotEmpty()
+  imageUrl: string;
+}
+
+export class UpdateMediaRequestDto {
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({
+    description: '게시글 ID',
+    example: '1231312124',
+  })
+  articleId: string;
+
+  @IsNotEmpty()
+  @ValidateNested({ each: true })
+  @Type(() => FileInfo)
+  thumbnailInfo: FileInfo;
+
+  @IsArray()
+  @IsNotEmpty()
+  @ValidateNested({ each: true })
+  @Type(() => FileInfo)
+  @ApiProperty({
+    description: '파일 정보 목록',
+    example: [{ imageUrl: 'aaaaaaa.com' }],
+  })
+  fileInfoList: FileInfo[];
+}

--- a/src/media/command/application/update/dto/update.request.dto.ts
+++ b/src/media/command/application/update/dto/update.request.dto.ts
@@ -2,9 +2,13 @@ import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { IsArray, IsNotEmpty, IsString, ValidateNested } from 'class-validator';
 
-class FileInfo {
+class ImageUrlInfo {
   @IsString()
   @IsNotEmpty()
+  @ApiProperty({
+    description: '이미지 경로',
+    example: 'https://aaaaaaa.com/aaaa.png',
+  })
   imageUrl: string;
 }
 
@@ -19,16 +23,20 @@ export class UpdateMediaRequestDto {
 
   @IsNotEmpty()
   @ValidateNested({ each: true })
-  @Type(() => FileInfo)
-  thumbnailInfo: FileInfo;
+  @Type(() => ImageUrlInfo)
+  @ApiProperty({
+    description: '썸네일 정보',
+    type: ImageUrlInfo,
+  })
+  thumbnailInfo: ImageUrlInfo;
 
   @IsArray()
   @IsNotEmpty()
   @ValidateNested({ each: true })
-  @Type(() => FileInfo)
+  @Type(() => ImageUrlInfo)
   @ApiProperty({
     description: '파일 정보 목록',
-    example: [{ imageUrl: 'aaaaaaa.com' }],
+    type: [ImageUrlInfo],
   })
-  fileInfoList: FileInfo[];
+  fileInfoList: ImageUrlInfo[];
 }

--- a/src/media/command/application/update/update.use-case.ts
+++ b/src/media/command/application/update/update.use-case.ts
@@ -1,0 +1,54 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { UpdateMediaRequestDto } from './dto/update.request.dto';
+import { Identifier } from 'src/shared/domain/value-object/identifier';
+import { S3Adapter } from '../../infrastructure/util/s3.adpater';
+import { MEDIA_COMMAND_REPOSITORY, MediaCommandRepository } from '../../domain/media.command.repository';
+import { Media } from '../../domain/media';
+
+@Injectable()
+export class UpdateMediaUseCase {
+  constructor(
+    @Inject(MEDIA_COMMAND_REPOSITORY)
+    private readonly mediaCommandRepository: MediaCommandRepository,
+    private readonly s3Adapter: S3Adapter,
+  ) {}
+
+  async execute(reqDto: UpdateMediaRequestDto): Promise<void> {
+    const { articleId, thumbnailInfo, fileInfoList } = reqDto;
+
+    const existingMedias = await this.mediaCommandRepository.findByArticleId(articleId);
+    const existingMap = new Map(existingMedias.map((m) => [m.order, m]));
+
+    const incomingMediaList: Media[] = [];
+    const incomingOrders = new Set<number>();
+
+    incomingOrders.add(0);
+    incomingMediaList.push(this.createMedia(articleId, thumbnailInfo.imageUrl, 0, existingMap.get(0)));
+
+    for (let i = 0; i < fileInfoList.length; i++) {
+      const order = i + 1;
+      const fileInfo = fileInfoList[i];
+
+      incomingOrders.add(order);
+      incomingMediaList.push(this.createMedia(articleId, fileInfo.imageUrl, order, existingMap.get(order)));
+    }
+
+    const toDelete = existingMedias.filter((media) => !incomingOrders.has(media.order));
+    if (toDelete.length > 0) {
+      await this.mediaCommandRepository.deleteByIds(toDelete.map((m) => m.id.value));
+    }
+
+    await this.mediaCommandRepository.updateAll(incomingMediaList);
+  }
+
+  private createMedia(articleId: string, imageUrl: string, order: number, existingMedia?: Media): Media {
+    return Media.create({
+      id: existingMedia?.id ?? Identifier.create(),
+      createdAt: existingMedia?.createdAt ?? new Date(),
+      updatedAt: new Date(),
+      order,
+      mediaPath: imageUrl,
+      articleId: Identifier.from(articleId),
+    });
+  }
+}

--- a/src/media/command/domain/media.command.repository.ts
+++ b/src/media/command/domain/media.command.repository.ts
@@ -4,6 +4,8 @@ export interface MediaCommandRepository {
   save(media: Media): Promise<void>;
   saveAll(meidaList: Media[]): Promise<void>;
   deleteByIds(mediaIds: string[]): Promise<void>;
+  findByArticleId(articleId: string): Promise<Media[]>;
+  updateAll(mediaList: Media[]): Promise<void>;
 }
 
 export const MEDIA_COMMAND_REPOSITORY = Symbol('MEDIA_COMMAND_REPOSITORY');

--- a/src/media/command/infrastructure/media.command.repository.impl.ts
+++ b/src/media/command/infrastructure/media.command.repository.impl.ts
@@ -17,14 +17,25 @@ export class MediaCommandRepositoryImpl implements MediaCommandRepository {
     await this.em.persistAndFlush(mediaEntity);
   }
 
-  async saveAll(meidaList: Media[]): Promise<void> {
-    const mediaEntites = meidaList.map((media) => MediaMapper.toEntity(media, this.em));
+  async saveAll(mediaList: Media[]): Promise<void> {
+    const mediaEntites = mediaList.map((media) => MediaMapper.toEntity(media, this.em));
     await this.em.persistAndFlush(mediaEntites);
   }
 
   async deleteByIds(mediaIds: string[]): Promise<void> {
     if (mediaIds.length === 0) return;
 
-    await this.ormRepository.nativeDelete({ id: { $in: mediaIds } });
+    await this.ormRepository.nativeDelete({ id: mediaIds });
+  }
+
+  async findByArticleId(articleId: string): Promise<Media[]> {
+    const mediaEntities = await this.ormRepository.find({ article: articleId }, { orderBy: { order: 'ASC' } });
+
+    return mediaEntities.map((mediaEntity) => MediaMapper.toDomain(mediaEntity));
+  }
+
+  async updateAll(mediaList: Media[]): Promise<void> {
+    const mediaEntites = mediaList.map((media) => MediaMapper.toEntity(media, this.em));
+    await this.em.upsertMany(mediaEntites);
   }
 }

--- a/src/media/command/infrastructure/util/s3.adpater.ts
+++ b/src/media/command/infrastructure/util/s3.adpater.ts
@@ -25,8 +25,9 @@ export class S3Adapter {
   async upload(articleId: string, fileName: string, mimeType: string) {
     const objectKey = this.generateKey(fileName, articleId);
     const presignedUrl = await this.generatePresignedUrl(mimeType, objectKey);
+    const imageUrl = this.generateImageUrl(objectKey);
 
-    return { presignedUrl, objectKey };
+    return { presignedUrl, imageUrl };
   }
 
   async delete() {}

--- a/src/media/command/media.command.module.ts
+++ b/src/media/command/media.command.module.ts
@@ -7,8 +7,9 @@ import { MikroOrmModule } from '@mikro-orm/nestjs';
 import { MediaEntity } from './infrastructure/media.entity';
 import { S3Adapter } from './infrastructure/util/s3.adpater';
 import { CreateMediaUseCase } from './application/create/create.use-case';
+import { UpdateMediaUseCase } from './application/update/update.use-case';
 
-const usecases = [GeneratePresignedUrlUseCase, CreateMediaUseCase];
+const usecases = [GeneratePresignedUrlUseCase, CreateMediaUseCase, UpdateMediaUseCase];
 
 @Module({
   imports: [MikroOrmModule.forFeature([MediaEntity])],

--- a/src/media/command/presentation/media.command.controller.ts
+++ b/src/media/command/presentation/media.command.controller.ts
@@ -31,6 +31,7 @@ export class MediaCommandController {
   }
 
   @Patch()
+  @MediaCommandDocs('update')
   async updateMedia(@Body() reqDto: UpdateMediaRequestDto): Promise<void> {
     await this.updateMediaUseCase.execute(reqDto);
   }

--- a/src/media/command/presentation/media.command.controller.ts
+++ b/src/media/command/presentation/media.command.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Patch, Post } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { GeneratePresignedUrlUseCase } from '../application/generate-presigned-url/generate-presigned-url.use-case';
 import { GeneratePresignedUrlRequestDto } from '../application/generate-presigned-url/dto/generate-presigned-url.request.dto';
@@ -6,6 +6,8 @@ import { GeneratePresignedUrlResponseDto } from '../application/generate-presign
 import { MediaCommandDocs } from './media.command.docs';
 import { CreateMediaRequestDto } from '../application/create/dto/create.request.dto';
 import { CreateMediaUseCase } from '../application/create/create.use-case';
+import { UpdateMediaRequestDto } from '../application/update/dto/update.request.dto';
+import { UpdateMediaUseCase } from '../application/update/update.use-case';
 
 @ApiTags('media')
 @Controller('media')
@@ -13,6 +15,7 @@ export class MediaCommandController {
   constructor(
     private readonly generatePresignedUrlUsecCase: GeneratePresignedUrlUseCase,
     private readonly createMediaUseCase: CreateMediaUseCase,
+    private readonly updateMediaUseCase: UpdateMediaUseCase,
   ) {}
 
   @Post('presigned-url')
@@ -25,5 +28,10 @@ export class MediaCommandController {
   @MediaCommandDocs('create')
   async createMedia(@Body() reqDto: CreateMediaRequestDto): Promise<void> {
     await this.createMediaUseCase.execute(reqDto);
+  }
+
+  @Patch()
+  async updateMedia(@Body() reqDto: UpdateMediaRequestDto): Promise<void> {
+    await this.updateMediaUseCase.execute(reqDto);
   }
 }

--- a/src/media/command/presentation/media.command.docs.ts
+++ b/src/media/command/presentation/media.command.docs.ts
@@ -1,17 +1,21 @@
 import { applyDecorators } from '@nestjs/common';
 import {
   ApiBadRequestResponse,
+  ApiBody,
   ApiCreatedResponse,
   ApiForbiddenResponse,
   ApiInternalServerErrorResponse,
   ApiNotFoundResponse,
+  ApiOkResponse,
   ApiOperation,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 import { createDocs } from 'src/shared/presentation/docs/base.docs';
 import { GeneratePresignedUrlResponseDto } from '../application/generate-presigned-url/dto/generate-presigned-url.response.dto';
+import { UpdateMediaRequestDto } from '../application/update/dto/update.request.dto';
+import { CreateMediaRequestDto } from '../application/create/dto/create.request.dto';
 
-export type MediaCommandEndpoint = 'presignedUrl' | 'create';
+export type MediaCommandEndpoint = 'presignedUrl' | 'create' | 'update';
 
 export const MediaCommandDocs = createDocs<MediaCommandEndpoint>({
   presignedUrl: () =>
@@ -63,8 +67,53 @@ export const MediaCommandDocs = createDocs<MediaCommandEndpoint>({
         summary: '미디어 생성',
         description: 'S3에 파일을 업로드하고 메타데이터를 저장합니다.',
       }),
+      ApiBody({
+        description: '미디어 생성 request dto',
+        type: CreateMediaRequestDto,
+      }),
       ApiCreatedResponse({
         description: '미디어가 성공적으로 생성됨',
+      }),
+      ApiBadRequestResponse({
+        description: '잘못된 요청 형식',
+      }),
+      ApiUnauthorizedResponse({
+        description: '인증 실패',
+      }),
+      ApiInternalServerErrorResponse({
+        description: '서버 오류',
+      }),
+    ),
+  update: () =>
+    applyDecorators(
+      ApiOperation({
+        summary: '미디어 수정',
+        description: `
+        S3에 파일 삭제, 순서 변경, 삽입을 수행
+
+        1. POST /media/presigned-url 
+            => S3에 파일 업로드를 위한 Presigned URL을 생성
+            => [{presignedUrl, objectKey}] 받음
+            => thumbnail과 일반 이미지의 presignedUrl이 구분되어 있음
+
+        2. PUT https://presigendUrl~~~
+            => 2번에서 받은 presignedUrl을 통해 파일 업로드
+            => 성공 시 200 OK 응답
+
+        3. PATCH /media/
+            => 수정된 imageUrl 배열과 함께 api 요청
+            => 삭제하고자 하는 이미지 경로는 배열에서 제외
+        
+        4. PATCH /article/{articleId}
+            => 이미지를 제외한 게시글 정보 수정 api 요청
+        `,
+      }),
+      ApiBody({
+        description: '미디어 수정 request dto',
+        type: UpdateMediaRequestDto,
+      }),
+      ApiOkResponse({
+        description: '미디어가 성공적으로 수정됨',
       }),
       ApiBadRequestResponse({
         description: '잘못된 요청 형식',


### PR DESCRIPTION
**작업내용**
- 게시글 수정 api(거의 media 부분 위주로) 수정
  - media 삭제를 update-article usecase에서 진행하지 않고 update media usecase에서 진행
  - presigned url 생성 시, 썸네일을 선택적 필드로 변경 => 필수로 하면 update할 때 오류
  - 이미지 경로 배열을 받아서, 기존 DB의 이미지 경로들과 비교 후, 없는 건 삭제, 순서 변경, 새로운 건 추가.
 
- 게시글 상세 조회 시, 일반 이미지들 보내줄 때, 썸네일 제외. andWhere(order != 0) 추가

- swagger 문서 수정