### PR TITLE
행사 수정할 때 description과 registrationUrl에 빈 문자열 허용하도록 수정

### DIFF
--- a/src/article/command/domain/article.ts
+++ b/src/article/command/domain/article.ts
@@ -41,11 +41,11 @@ export class Article extends BaseDomainEntity<ArticleProps> {
       throw new Error('위치는 필수입니다.');
     }
 
-    if (!this.props.description) {
+    if (this.props.description === undefined || this.props.description === null) {
       throw new Error('설명은 필수입니다.');
     }
 
-    if (!this.props.registrationUrl) {
+    if (this.props.registrationUrl === undefined || this.props.registrationUrl === null) {
       throw new Error('등록 URL은 필수입니다.');
     }
 


### PR DESCRIPTION
- DTO에서 Length(0)으로만 하면 여전히 에러가 떠서 article.ts에서 props에 대한 throw의 조건을 수정함