### PR TITLE
'임박한' 정렬 기준을 신청 기간 기준으로 변경

### DIFF
--- a/src/article/command/application/create-article/dto/create-article.request.dto.ts
+++ b/src/article/command/application/create-article/dto/create-article.request.dto.ts
@@ -1,5 +1,5 @@
 import { Type } from 'class-transformer';
-import { IsArray, IsNotEmpty, IsString } from 'class-validator';
+import { IsArray, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 export class CreateArticleRequestDto {
   @IsString()
@@ -26,12 +26,15 @@ export class CreateArticleRequestDto {
   endAt: string;
 
   @IsString()
+  @IsOptional()
   registrationUrl: string;
 
   @IsString()
+  @IsOptional()
   registrationStartAt?: string;
 
   @IsString()
+  @IsOptional()
   registrationEndAt?: string;
 
   @IsArray()

--- a/src/article/command/application/update-article/dto/update-article.request.dto.ts
+++ b/src/article/command/application/update-article/dto/update-article.request.dto.ts
@@ -74,6 +74,7 @@ export class UpdateArticleRequestDto {
     required: false,
   })
   @IsString()
+  @Length(0)
   @IsOptional()
   registrationStartAt?: string;
 
@@ -83,6 +84,7 @@ export class UpdateArticleRequestDto {
     required: false,
   })
   @IsString()
+  @Length(0)
   @IsOptional()
   registrationEndAt?: string;
 

--- a/src/article/command/domain/article.ts
+++ b/src/article/command/domain/article.ts
@@ -169,11 +169,16 @@ export class Article extends BaseDomainEntity<ArticleProps> {
     if (props.endAt !== undefined && props.endAt !== this.props.endAt) {
       this.props.endAt = props.endAt;
     }
-    if (props.registrationStartAt !== undefined && props.registrationStartAt !== this.props.registrationStartAt) {
-      this.props.registrationStartAt = props.registrationStartAt;
+    // Optional date fields: allow explicit clearing when the key is present even if value is undefined
+    if (Object.prototype.hasOwnProperty.call(props, 'registrationStartAt')) {
+      if (props.registrationStartAt !== this.props.registrationStartAt) {
+        this.props.registrationStartAt = props.registrationStartAt;
+      }
     }
-    if (props.registrationEndAt !== undefined && props.registrationEndAt !== this.props.registrationEndAt) {
-      this.props.registrationEndAt = props.registrationEndAt;
+    if (Object.prototype.hasOwnProperty.call(props, 'registrationEndAt')) {
+      if (props.registrationEndAt !== this.props.registrationEndAt) {
+        this.props.registrationEndAt = props.registrationEndAt;
+      }
     }
 
     this.props.updatedAt = new Date();

--- a/src/article/query/application/article-list/dto/get-article-list.request.dto.ts
+++ b/src/article/query/application/article-list/dto/get-article-list.request.dto.ts
@@ -26,13 +26,13 @@ export class GetArticleListRequestDto {
 
   @ApiProperty({
     description: '정렬 기준',
-    example: 'createdAt',
+    example: 'registrationEndAt',
     required: false,
-    enum: ['createdAt', 'scrapCount', 'viewCount'],
+    enum: ['registrationEndAt', 'scrapCount', 'viewCount'],
   })
   @IsOptional()
-  @IsIn(['createdAt', 'scrapCount', 'viewCount'])
-  sortBy?: 'createdAt' | 'scrapCount' | 'viewCount';
+  @IsIn(['registrationEndAt', 'scrapCount', 'viewCount'])
+  sortBy?: 'registrationEndAt' | 'scrapCount' | 'viewCount';
 
   @ApiProperty({
     description: '페이지 번호',

--- a/src/article/query/domain/repository/article.query.repository.ts
+++ b/src/article/query/domain/repository/article.query.repository.ts
@@ -6,7 +6,7 @@ export interface ArticleQueryRepository {
   findAllByCriteria(
     tags?: string[],
     isFinished?: boolean,
-    sortBy?: 'createdAt' | 'scrapCount' | 'viewCount',
+    sortBy?: 'registrationEndAt' | 'scrapCount' | 'viewCount',
     page?: number,
     limit?: number,
   ): Promise<ArticleModel[]>;

--- a/src/article/query/infrastructure/article.query.repository.impl.ts
+++ b/src/article/query/infrastructure/article.query.repository.impl.ts
@@ -86,11 +86,14 @@ export class ArticleQueryRepositoryImpl implements ArticleQueryRepository {
   async findAllByCriteria(
     tags?: string[],
     isFinished?: boolean,
-    sortBy?: 'createdAt' | 'scrapCount' | 'viewCount',
+    sortBy?: 'registrationEndAt' | 'scrapCount' | 'viewCount',
     // page?: number,
     // limit?: number,
   ): Promise<ArticleModel[]> {
     const query = this.ormRepository.createQueryBuilder('a');
+    // 런타임 안전 가드: 허용되지 않은 sortBy 값이 오면 기본 정렬로 처리
+    const safeSortBy: 'registrationEndAt' | 'scrapCount' | 'viewCount' | undefined =
+      sortBy === 'registrationEndAt' || sortBy === 'scrapCount' || sortBy === 'viewCount' ? sortBy : undefined;
     query
       .select([
         'a.id',
@@ -135,10 +138,21 @@ export class ArticleQueryRepositoryImpl implements ArticleQueryRepository {
     // isFinished가 true이거나 undefined면 모든 것을 조회 (필터링 없음)
 
     // 정렬
-    if (sortBy) {
-      query.orderBy({ [`a.${sortBy}`]: 'DESC' });
+    if (!safeSortBy || safeSortBy === 'registrationEndAt') {
+      // 현재 시간에 가장 가까운 순서 (미래 우선), 값 없으면 endAt 사용
+      query.orderBy([
+        {
+          [sql`CASE WHEN COALESCE(a.registration_end_at, a.end_at) >= NOW() THEN 0 ELSE 1 END` as unknown as string]:
+            'asc',
+        },
+        {
+          [sql`ABS(TIMESTAMPDIFF(SECOND, COALESCE(a.registration_end_at, a.end_at), NOW()))` as unknown as string]:
+            'asc',
+        },
+      ]);
     } else {
-      query.orderBy({ 'a.createdAt': 'DESC' }); // 기본 정렬은 생성일 기준
+      // 기타 정렬 키는 기존 방식 유지
+      query.orderBy({ [`a.${safeSortBy}`]: 'DESC' });
     }
 
     // query.limit(limit).offset((page - 1) * limit);


### PR DESCRIPTION
- 행사 리스트를 불러오는 API의 request에서 sortBy에 있던 createdAt을 registrationEndAt으로 변경
- registrationEndAt이 현재 시간과 가까운 순으로 정렬하고, registrationEndAt이 없으면 endAt을 기준으로 정렬하도록 구현